### PR TITLE
fix(test): Skip postfix operator tests on Cloudberry

### DIFF
--- a/integration/predata_operators_queries_test.go
+++ b/integration/predata_operators_queries_test.go
@@ -14,6 +14,10 @@ import (
 var _ = Describe("backup integration tests", func() {
 	Describe("GetOperators", func() {
 		It("returns a slice of operators", func() {
+			if connectionPool.Version.IsCBDB() {
+				Skip("Cloudberry does not support postfix operators, which this test requires.")
+			}
+
 			testhelper.AssertQueryRuns(connectionPool, "CREATE OPERATOR public.## (LEFTARG = bigint, PROCEDURE = numeric_fac)")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP OPERATOR public.## (bigint, NONE)")
 


### PR DESCRIPTION
The integration tests for creating postfix operators were failing on Cloudberry because it does not support creating an operator with only a LEFTARG. This is an intentional design difference from Greenplum 7, as Cloudberry is based on a newer PostgreSQL version (14) that removed this feature.

Instead of adapting the tests to assert an error, which would be testing a negative case, this commit modifies them to be skipped entirely when running against Cloudberry.

This approach is cleaner because the feature being tested is fundamentally absent on this platform. It keeps the test suite passing on Cloudberry while preserving the original test logic for Greenplum 7 and other compatible databases.