### PR TITLE
fix(relations): Ensure materialized view access method is restored

### DIFF
--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -444,8 +444,12 @@ func PrintCreateViewStatement(metadataFile *utils.FileWithByteCount, objToc *toc
 	if !view.IsMaterialized {
 		metadataFile.MustPrintf("\n\nCREATE VIEW %s%s AS %s\n", view.FQN(), view.Options, view.Definition.String)
 	} else {
-		metadataFile.MustPrintf("\n\nCREATE MATERIALIZED VIEW %s%s%s AS %s\nWITH NO DATA\n%s;\n",
-			view.FQN(), view.Options, tablespaceClause, view.Definition.String[:len(view.Definition.String)-1], view.DistPolicy.Policy)
+		accessMethodClause := ""
+		if view.AccessMethodName != "" {
+			accessMethodClause = fmt.Sprintf(" USING %s", view.AccessMethodName)
+		}
+		metadataFile.MustPrintf("\n\nCREATE MATERIALIZED VIEW %s%s%s%s AS %s\nWITH NO DATA\n%s;\n",
+			view.FQN(), accessMethodClause, view.Options, tablespaceClause, view.Definition.String[:len(view.Definition.String)-1], view.DistPolicy.Policy)
 	}
 	section, entry := view.GetMetadataEntry()
 	tier := globalTierMap[view.GetUniqueID()]

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -576,6 +576,9 @@ SET SUBPARTITION TEMPLATE ` + `
 		})
 		It("creates a view with privileges, owner, security label, and comment", func() {
 			view := backup.View{Oid: 1, Schema: "public", Name: "simplemview", Definition: sql.NullString{String: " SELECT 1 AS a;", Valid: true}, IsMaterialized: true, DistPolicy: backup.DistPolicy{Policy: "DISTRIBUTED BY (a)"}}
+			if (connectionPool.Version.IsGPDB() && connectionPool.Version.AtLeast("7")) || connectionPool.Version.IsCBDB() {
+				view.AccessMethodName = "heap"
+			}
 			viewMetadata := testutils.DefaultMetadata(toc.OBJ_MATERIALIZED_VIEW, true, true, true, includeSecurityLabels)
 
 			backup.PrintCreateViewStatement(backupfile, tocfile, view, viewMetadata)
@@ -594,7 +597,9 @@ SET SUBPARTITION TEMPLATE ` + `
 		})
 		It("creates a materialized view with options", func() {
 			view := backup.View{Oid: 1, Schema: "public", Name: "simplemview", Options: " WITH (fillfactor=10)", Definition: sql.NullString{String: " SELECT 1 AS a;", Valid: true}, IsMaterialized: true, DistPolicy: backup.DistPolicy{Policy: "DISTRIBUTED BY (a)"}}
-
+			if (connectionPool.Version.IsGPDB() && connectionPool.Version.AtLeast("7")) || connectionPool.Version.IsCBDB() {
+				view.AccessMethodName = "heap"
+			}
 			backup.PrintCreateViewStatement(backupfile, tocfile, view, backup.ObjectMetadata{})
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -512,6 +512,9 @@ PARTITION BY LIST (gender)
 
 			results := backup.GetAllViews(connectionPool)
 			materialView := backup.View{Oid: 1, Schema: "public", Name: "simplematerialview", Definition: sql.NullString{String: " SELECT 1 AS a;", Valid: true}, IsMaterialized: true, DistPolicy: backup.DistPolicy{Policy: "DISTRIBUTED BY (a)"}}
+			if (connectionPool.Version.IsGPDB() && connectionPool.Version.AtLeast("7")) || connectionPool.Version.IsCBDB() {
+				materialView.AccessMethodName = "heap"
+			}
 
 			materialView.Oid = testutils.OidFromObjectName(connectionPool, "public", "simplematerialview", backup.TYPE_RELATION)
 			Expect(results).To(HaveLen(1))
@@ -526,7 +529,9 @@ PARTITION BY LIST (gender)
 
 			results := backup.GetAllViews(connectionPool)
 			materialView := backup.View{Oid: 1, Schema: "public", Name: "simplematerialview", Definition: sql.NullString{String: " SELECT 1 AS a;", Valid: true}, Options: " WITH (fillfactor=50, autovacuum_enabled=false)", IsMaterialized: true, DistPolicy: backup.DistPolicy{Policy: "DISTRIBUTED BY (a)"}}
-
+			if (connectionPool.Version.IsGPDB() && connectionPool.Version.AtLeast("7")) || connectionPool.Version.IsCBDB() {
+				materialView.AccessMethodName = "heap"
+			}
 			materialView.Oid = testutils.OidFromObjectName(connectionPool, "public", "simplematerialview", backup.TYPE_RELATION)
 			Expect(results).To(HaveLen(1))
 			structmatcher.ExpectStructsToMatchExcluding(&materialView, &results[0], "ColumnDefs", "DistPolicy.Oid")
@@ -542,7 +547,9 @@ PARTITION BY LIST (gender)
 
 			results := backup.GetAllViews(connectionPool)
 			materialView := backup.View{Oid: 1, Schema: "public", Name: "simplematerialview", Definition: sql.NullString{String: " SELECT 1 AS a;", Valid: true}, Tablespace: "test_tablespace", IsMaterialized: true, DistPolicy: backup.DistPolicy{Policy: "DISTRIBUTED BY (a)"}}
-
+			if (connectionPool.Version.IsGPDB() && connectionPool.Version.AtLeast("7")) || connectionPool.Version.IsCBDB() {
+				materialView.AccessMethodName = "heap"
+			}
 			Expect(results).To(HaveLen(1))
 			structmatcher.ExpectStructsToMatchExcluding(&materialView, &results[0], "Oid", "ColumnDefs", "DistPolicy.Oid")
 		})


### PR DESCRIPTION
On Cloudberry, Greenplum 7+, materialized views must be created with a specific access method (e.g., 'heap', 'ao_row') and associated storage options in the 'WITH' clause (e.g., 'compresstype=zstd').

The prior implementation did not back up the 'USING' clause. During restore, the database would default to another access method (e.g., 'heap') which might not support the view's storage options. This incompatibility caused the 'CREATE MATERIALIZED VIEW' command to fail validation.

This commit corrects the failure by:
- Updating the view query for Cloudberry, GPDB 7+ to fetch the access method.
- Modifying DDL generation to include the 'USING' clause.
- Updating integration tests to verify the fix.

Fixes #61