### PR TITLE
CI: add smoke test for command validation

### DIFF
--- a/.github/workflows/build_and_unit_test.yml
+++ b/.github/workflows/build_and_unit_test.yml
@@ -40,6 +40,7 @@ jobs:
 
     - name: Smoke Test
       run: |
+        set -euo pipefail
         cd ${GOPATH}/src/github.com/apache/cloudberry-backup
         echo "Running smoke tests..."
         echo "=== Testing gpbackup ==="

--- a/.github/workflows/build_and_unit_test.yml
+++ b/.github/workflows/build_and_unit_test.yml
@@ -38,6 +38,27 @@ jobs:
         cd ${GOPATH}/src/github.com/apache/cloudberry-backup
         make build
 
+    - name: Smoke Test
+      run: |
+        cd ${GOPATH}/src/github.com/apache/cloudberry-backup
+        echo "Running smoke tests..."
+        echo "=== Testing gpbackup ==="
+        ${GOPATH}/bin/gpbackup --version
+        ${GOPATH}/bin/gpbackup --help > /dev/null
+        echo "=== Testing gprestore ==="
+        ${GOPATH}/bin/gprestore --version
+        ${GOPATH}/bin/gprestore --help > /dev/null
+        echo "=== Testing gpbackup_helper ==="
+        ${GOPATH}/bin/gpbackup_helper --version
+        ${GOPATH}/bin/gpbackup_helper --help > /dev/null
+        echo "=== Testing gpbackup_s3_plugin ==="
+        ${GOPATH}/bin/gpbackup_s3_plugin --version
+        ${GOPATH}/bin/gpbackup_s3_plugin --help > /dev/null
+        echo "=== Testing gpbackman ==="
+        ${GOPATH}/bin/gpbackman --version
+        ${GOPATH}/bin/gpbackman --help > /dev/null
+        echo "=== All smoke tests passed ==="
+
     - name: Unit Test
       run: |
         cd ${GOPATH}/src/github.com/apache/cloudberry-backup

--- a/.github/workflows/cloudberry-backup-ci.yml
+++ b/.github/workflows/cloudberry-backup-ci.yml
@@ -187,7 +187,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_target: [unit, integration, end_to_end, s3_plugin_e2e, regression, scale]
+        test_target: [smoke, unit, integration, end_to_end, s3_plugin_e2e, regression, scale]
 
     steps:
       - name: Free Disk Space
@@ -316,6 +316,25 @@ jobs:
 
             set +e
             case "${TEST_TARGET}" in
+              smoke)
+                echo "Running smoke tests..."
+                echo "=== Testing gpbackup ==="
+                ${GPHOME}/bin/gpbackup --version
+                ${GPHOME}/bin/gpbackup --help > /dev/null
+                echo "=== Testing gprestore ==="
+                ${GPHOME}/bin/gprestore --version
+                ${GPHOME}/bin/gprestore --help > /dev/null
+                echo "=== Testing gpbackup_helper ==="
+                ${GPHOME}/bin/gpbackup_helper --version
+                ${GPHOME}/bin/gpbackup_helper --help > /dev/null
+                echo "=== Testing gpbackup_s3_plugin ==="
+                ${GPHOME}/bin/gpbackup_s3_plugin --version
+                ${GPHOME}/bin/gpbackup_s3_plugin --help > /dev/null
+                echo "=== Testing gpbackman ==="
+                ${GPHOME}/bin/gpbackman --version
+                ${GPHOME}/bin/gpbackman --help > /dev/null
+                echo "=== All smoke tests passed ===" | tee "${TEST_LOG_ROOT}/cloudberry-backup-smoke.log"
+                ;;
               unit)
                 make unit 2>&1 | tee "${TEST_LOG_ROOT}/cloudberry-backup-unit.log"
                 ;;

--- a/.github/workflows/cloudberry-backup-ci.yml
+++ b/.github/workflows/cloudberry-backup-ci.yml
@@ -317,6 +317,7 @@ jobs:
             set +e
             case "${TEST_TARGET}" in
               smoke)
+                set -e
                 echo "Running smoke tests..."
                 echo "=== Testing gpbackup ==="
                 ${GPHOME}/bin/gpbackup --version


### PR DESCRIPTION
Add smoke test to verify all cloudberry-backup commands (gpbackup, gprestore, gpbackup_helper, gpbackup_s3_plugin, gpbackman) can be built, installed to GPHOME, and executed with --version and --help flags.

This provides fast feedback on basic functionality before running more expensive integration tests.

<!--Thank you for contributing! -->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that CICD workflow is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-backup/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.
