### PR TITLE
Docs: update installation command to use specific version tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 1. Downloading the latest version:
 
 ```bash
-go install github.com/apache/cloudberry-backup@latest
+go install github.com/apache/cloudberry-backup@2.1.0-incubating
 ```
+
+**Note:** Please use the specific version `@2.1.0-incubating` instead of `@latest`. The `@latest` tag will install an older version due to Go modules version resolution rules.
 
 This will place the code in `$GOPATH/pkg/mod/github.com/apache/cloudberry-backup`.
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,17 @@ export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 
 ## Download & Build
 
-1. Downloading the latest version:
+1. Downloading:
 
 ```bash
+# Download the stable release version
 go install github.com/apache/cloudberry-backup@2.1.0-incubating
+
+# Or download the latest development version from main branch
+go install github.com/apache/cloudberry-backup@main
 ```
 
-**Note:** Please use the specific version `@2.1.0-incubating` instead of `@latest`. The `@latest` tag will install an older version due to Go modules version resolution rules.
+**Note:** Please use the specific version `@2.1.0-incubating` or `@main` instead of `@latest`. The `@latest` tag will install an older version due to Go modules version resolution rules.
 
 This will place the code in `$GOPATH/pkg/mod/github.com/apache/cloudberry-backup`.
 


### PR DESCRIPTION
Update the installation instructions in README.md to use the specific version tag @2.1.0-incubating instead of @latest.

The @latest tag resolves to v1.0.2 due to Go modules semantic versioning rules, which only recognizes version tags with 'v' prefix (v1.0.0, v1.0.1, v1.0.2). The 2.1.0-incubating tag, while functional when specified directly, is not recognized as a semantic version by Go modules.

Added a note to clarify why users should use the specific version tag to avoid confusion and ensure they install the correct latest version.

<!--Thank you for contributing! -->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that CICD workflow is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-backup/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.
