### PR TITLE
Align release artifact naming with Apache incubator conventions

### DIFF
--- a/cloudberry-backup-release.sh
+++ b/cloudberry-backup-release.sh
@@ -510,13 +510,16 @@ section "Staging release: $TAG"
 
   section "Creating Source Tarball"
 
-  TAR_NAME="apache-cloudberry-backup-${TAG}-src.tar.gz"
+  TAR_NAME="apache-cloudberry-backup-${VERSION_FILE}-incubating-src.tar.gz"
   TMP_DIR=$(mktemp -d)
   trap 'rm -rf "$TMP_DIR"' EXIT
 
   # Set environment variables to prevent macOS extended attributes
   export COPYFILE_DISABLE=1
   export COPY_EXTENDED_ATTRIBUTES_DISABLE=1
+
+  # Use base version (without -rcN) for both tarball filename and extracted directory name.
+  # This allows direct svn mv to release repository after voting without renaming.
 
   git archive --format=tar --prefix="apache-cloudberry-backup-${VERSION_FILE}-incubating/" "$TAG" | tar -x -C "$TMP_DIR"
 


### PR DESCRIPTION
Use base version (without -rcN suffix) for release tarball filename to align with Apache incubator release conventions.

Changes:
- Modified TAR_NAME to use ${VERSION_FILE} instead of ${TAG}
- Tarball filename now follows pattern: apache-cloudberry-backup-${VERSION_FILE}-incubating-src.tar.gz
- Example: apache-cloudberry-backup-2.0.0-incubating-src.tar.gz (instead of apache-cloudberry-backup-2.0.0-incubating-rc1-src.tar.gz)

Benefits:
- Enables direct 'svn mv' to release repository after voting without renaming artifacts
- Aligns with Apache release best practices where RC identifiers are used only for Git tags and voting process, not in final artifact names
- Maintains consistency between tarball filename and extracted directory name

The extracted directory name remains unchanged:
apache-cloudberry-backup-${VERSION_FILE}-incubating/

<!--Thank you for contributing! -->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that CICD workflow is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-backup/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.
