### PR TITLE
gpbackman: env-var fallback for --history-db and fail loud when DB is missing

### DIFF
--- a/gpbackman/COMMANDS.md
+++ b/gpbackman/COMMANDS.md
@@ -72,7 +72,7 @@ For non local backups the following logic are applied:
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for in the current directory. Pass `--auto-load-history-db` to resolve it from `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`) instead.
+If the --history-db option is not specified, the history database is looked for in the current directory. Pass `--auto-load-history-db` to resolve it from `$COORDINATOR_DATA_DIRECTORY` instead.
 
 Usage:
   gpbackman backup-clean [flags]
@@ -158,7 +158,7 @@ For non local backups the following logic are applied:
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for in the current directory. Pass `--auto-load-history-db` to resolve it from `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`) instead.
+If the --history-db option is not specified, the history database is looked for in the current directory. Pass `--auto-load-history-db` to resolve it from `$COORDINATOR_DATA_DIRECTORY` instead.
 
 Usage:
   gpbackman backup-delete [flags]
@@ -256,7 +256,7 @@ To display the "object filtering details" column for all backups without using -
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for in the current directory. Pass `--auto-load-history-db` to resolve it from `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`) instead.
+If the --history-db option is not specified, the history database is looked for in the current directory. Pass `--auto-load-history-db` to resolve it from `$COORDINATOR_DATA_DIRECTORY` instead.
 
 Usage:
   gpbackman backup-info [flags]
@@ -455,7 +455,7 @@ Only --older-than-days or --before-timestamp option must be specified, not both.
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for in the current directory. Pass `--auto-load-history-db` to resolve it from `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`) instead.
+If the --history-db option is not specified, the history database is looked for in the current directory. Pass `--auto-load-history-db` to resolve it from `$COORDINATOR_DATA_DIRECTORY` instead.
 
 Usage:
   gpbackman history-clean [flags]
@@ -524,7 +524,7 @@ It is not necessary to use the --plugin-report-file-path flag for the following 
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for in the current directory. Pass `--auto-load-history-db` to resolve it from `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`) instead.
+If the --history-db option is not specified, the history database is looked for in the current directory. Pass `--auto-load-history-db` to resolve it from `$COORDINATOR_DATA_DIRECTORY` instead.
 
 Usage:
   gpbackman report-info [flags]

--- a/gpbackman/COMMANDS.md
+++ b/gpbackman/COMMANDS.md
@@ -72,7 +72,7 @@ For non local backups the following logic are applied:
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.
+If the --history-db option is not specified, the history database is looked for under `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`); if neither variable is set, the current directory is used as a last resort.
 
 Usage:
   gpbackman backup-clean [flags]
@@ -158,7 +158,7 @@ For non local backups the following logic are applied:
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.
+If the --history-db option is not specified, the history database is looked for under `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`); if neither variable is set, the current directory is used as a last resort.
 
 Usage:
   gpbackman backup-delete [flags]
@@ -256,7 +256,7 @@ To display the "object filtering details" column for all backups without using -
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.
+If the --history-db option is not specified, the history database is looked for under `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`); if neither variable is set, the current directory is used as a last resort.
 
 Usage:
   gpbackman backup-info [flags]
@@ -455,7 +455,7 @@ Only --older-than-days or --before-timestamp option must be specified, not both.
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.
+If the --history-db option is not specified, the history database is looked for under `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`); if neither variable is set, the current directory is used as a last resort.
 
 Usage:
   gpbackman history-clean [flags]
@@ -524,7 +524,7 @@ It is not necessary to use the --plugin-report-file-path flag for the following 
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.
+If the --history-db option is not specified, the history database is looked for under `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`); if neither variable is set, the current directory is used as a last resort.
 
 Usage:
   gpbackman report-info [flags]

--- a/gpbackman/COMMANDS.md
+++ b/gpbackman/COMMANDS.md
@@ -72,7 +72,7 @@ For non local backups the following logic are applied:
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for under `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`); if neither variable is set, the current directory is used as a last resort.
+If the --history-db option is not specified, the history database is looked for in the current directory. Pass `--auto-load-history-db` to resolve it from `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`) instead.
 
 Usage:
   gpbackman backup-clean [flags]
@@ -158,7 +158,7 @@ For non local backups the following logic are applied:
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for under `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`); if neither variable is set, the current directory is used as a last resort.
+If the --history-db option is not specified, the history database is looked for in the current directory. Pass `--auto-load-history-db` to resolve it from `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`) instead.
 
 Usage:
   gpbackman backup-delete [flags]
@@ -256,7 +256,7 @@ To display the "object filtering details" column for all backups without using -
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for under `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`); if neither variable is set, the current directory is used as a last resort.
+If the --history-db option is not specified, the history database is looked for in the current directory. Pass `--auto-load-history-db` to resolve it from `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`) instead.
 
 Usage:
   gpbackman backup-info [flags]
@@ -455,7 +455,7 @@ Only --older-than-days or --before-timestamp option must be specified, not both.
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for under `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`); if neither variable is set, the current directory is used as a last resort.
+If the --history-db option is not specified, the history database is looked for in the current directory. Pass `--auto-load-history-db` to resolve it from `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`) instead.
 
 Usage:
   gpbackman history-clean [flags]
@@ -524,7 +524,7 @@ It is not necessary to use the --plugin-report-file-path flag for the following 
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for under `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`); if neither variable is set, the current directory is used as a last resort.
+If the --history-db option is not specified, the history database is looked for in the current directory. Pass `--auto-load-history-db` to resolve it from `$COORDINATOR_DATA_DIRECTORY` (then `$MASTER_DATA_DIRECTORY`) instead.
 
 Usage:
   gpbackman report-info [flags]

--- a/gpbackman/README.md
+++ b/gpbackman/README.md
@@ -53,7 +53,7 @@ Available Commands:
 
 Flags:
   -h, --help                       help for gpbackman
-      --auto-load-history-db       resolve gpbackup_history.db from $COORDINATOR_DATA_DIRECTORY (or $MASTER_DATA_DIRECTORY) when --history-db is unset
+      --auto-load-history-db       resolve gpbackup_history.db from $COORDINATOR_DATA_DIRECTORY when --history-db is unset
       --history-db string          full path to the gpbackup_history.db file
       --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
       --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")

--- a/gpbackman/README.md
+++ b/gpbackman/README.md
@@ -53,7 +53,8 @@ Available Commands:
 
 Flags:
   -h, --help                       help for gpbackman
-      --history-db string          full path to the gpbackup_history.db file (if unset, falls back to $COORDINATOR_DATA_DIRECTORY/gpbackup_history.db, then $MASTER_DATA_DIRECTORY/gpbackup_history.db, then the current directory)
+      --auto-load-history-db       resolve gpbackup_history.db from $COORDINATOR_DATA_DIRECTORY (or $MASTER_DATA_DIRECTORY) when --history-db is unset
+      --history-db string          full path to the gpbackup_history.db file
       --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
       --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")
       --log-level-file string      level for file logging (error, info, debug, verbose) (default "info")

--- a/gpbackman/README.md
+++ b/gpbackman/README.md
@@ -53,7 +53,7 @@ Available Commands:
 
 Flags:
   -h, --help                       help for gpbackman
-      --history-db string          full path to the gpbackup_history.db file
+      --history-db string          full path to the gpbackup_history.db file (if unset, falls back to $COORDINATOR_DATA_DIRECTORY/gpbackup_history.db, then $MASTER_DATA_DIRECTORY/gpbackup_history.db, then the current directory)
       --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
       --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")
       --log-level-file string      level for file logging (error, info, debug, verbose) (default "info")

--- a/gpbackman/cmd/backup_clean.go
+++ b/gpbackman/cmd/backup_clean.go
@@ -77,7 +77,7 @@ For non local backups the following logic are applied:
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for in the current directory. To resolve it from $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY) instead, pass the --auto-load-history-db flag.`,
+If the --history-db option is not specified, the history database is looked for in the current directory. To resolve it from $COORDINATOR_DATA_DIRECTORY instead, pass the --auto-load-history-db flag.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)

--- a/gpbackman/cmd/backup_clean.go
+++ b/gpbackman/cmd/backup_clean.go
@@ -77,7 +77,7 @@ For non local backups the following logic are applied:
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for under $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY); if neither variable is set, the current directory is used as a last resort.`,
+If the --history-db option is not specified, the history database is looked for in the current directory. To resolve it from $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY) instead, pass the --auto-load-history-db flag.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)
@@ -205,7 +205,7 @@ func doCleanBackup() {
 }
 
 func cleanBackup() error {
-	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
+	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB, rootAutoLoadHistoryDB))
 	if err != nil {
 		gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("open", err))
 		return err

--- a/gpbackman/cmd/backup_clean.go
+++ b/gpbackman/cmd/backup_clean.go
@@ -77,7 +77,7 @@ For non local backups the following logic are applied:
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.`,
+If the --history-db option is not specified, the history database is looked for under $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY); if neither variable is set, the current directory is used as a last resort.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)

--- a/gpbackman/cmd/backup_delete.go
+++ b/gpbackman/cmd/backup_delete.go
@@ -84,7 +84,7 @@ For non local backups the following logic are applied:
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for under $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY); if neither variable is set, the current directory is used as a last resort.`,
+If the --history-db option is not specified, the history database is looked for in the current directory. To resolve it from $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY) instead, pass the --auto-load-history-db flag.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)
@@ -205,7 +205,7 @@ func doDeleteBackup() {
 }
 
 func deleteBackup() error {
-	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
+	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB, rootAutoLoadHistoryDB))
 	if err != nil {
 		gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("open", err))
 		return err

--- a/gpbackman/cmd/backup_delete.go
+++ b/gpbackman/cmd/backup_delete.go
@@ -84,7 +84,7 @@ For non local backups the following logic are applied:
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for in the current directory. To resolve it from $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY) instead, pass the --auto-load-history-db flag.`,
+If the --history-db option is not specified, the history database is looked for in the current directory. To resolve it from $COORDINATOR_DATA_DIRECTORY instead, pass the --auto-load-history-db flag.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)

--- a/gpbackman/cmd/backup_delete.go
+++ b/gpbackman/cmd/backup_delete.go
@@ -84,7 +84,7 @@ For non local backups the following logic are applied:
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.`,
+If the --history-db option is not specified, the history database is looked for under $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY); if neither variable is set, the current directory is used as a last resort.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)

--- a/gpbackman/cmd/backup_info.go
+++ b/gpbackman/cmd/backup_info.go
@@ -98,7 +98,7 @@ To display the "object filtering details" column for all backups without using -
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.`,
+If the --history-db option is not specified, the history database is looked for under $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY); if neither variable is set, the current directory is used as a last resort.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)

--- a/gpbackman/cmd/backup_info.go
+++ b/gpbackman/cmd/backup_info.go
@@ -98,7 +98,7 @@ To display the "object filtering details" column for all backups without using -
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for under $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY); if neither variable is set, the current directory is used as a last resort.`,
+If the --history-db option is not specified, the history database is looked for in the current directory. To resolve it from $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY) instead, pass the --auto-load-history-db flag.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)
@@ -226,7 +226,7 @@ func backupInfo() error {
 	}
 	t := tablewriter.NewWriter(os.Stdout)
 	initTable(t, opts.ShowDetails)
-	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
+	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB, rootAutoLoadHistoryDB))
 	if err != nil {
 		gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("open", err))
 		return err

--- a/gpbackman/cmd/backup_info.go
+++ b/gpbackman/cmd/backup_info.go
@@ -98,7 +98,7 @@ To display the "object filtering details" column for all backups without using -
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for in the current directory. To resolve it from $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY) instead, pass the --auto-load-history-db flag.`,
+If the --history-db option is not specified, the history database is looked for in the current directory. To resolve it from $COORDINATOR_DATA_DIRECTORY instead, pass the --auto-load-history-db flag.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)

--- a/gpbackman/cmd/constants.go
+++ b/gpbackman/cmd/constants.go
@@ -72,4 +72,12 @@ var (
 	beforeTimestamp string
 	// Timestamp to delete all backups after.
 	afterTimestamp string
+
+	// historyDBEnvVars lists, in priority order, the environment variables
+	// inspected when --history-db is not supplied. They are exported by the
+	// standard Cloudberry/Greenplum cluster environment scripts.
+	historyDBEnvVars = []string{
+		"COORDINATOR_DATA_DIRECTORY",
+		"MASTER_DATA_DIRECTORY",
+	}
 )

--- a/gpbackman/cmd/constants.go
+++ b/gpbackman/cmd/constants.go
@@ -35,6 +35,7 @@ const (
 
 	// Flags.
 	historyDBFlagName            = "history-db"
+	autoLoadHistoryDBFlagName    = "auto-load-history-db"
 	logFileFlagName              = "log-file"
 	logLevelConsoleFlagName      = "log-level-console"
 	logLevelFileFlagName         = "log-level-file"

--- a/gpbackman/cmd/constants.go
+++ b/gpbackman/cmd/constants.go
@@ -74,11 +74,10 @@ var (
 	// Timestamp to delete all backups after.
 	afterTimestamp string
 
-	// historyDBEnvVars lists, in priority order, the environment variables
-	// inspected when --history-db is not supplied. They are exported by the
-	// standard Cloudberry/Greenplum cluster environment scripts.
+	// historyDBEnvVars lists the environment variables inspected when
+	// --history-db is not supplied. Exported by the standard Cloudberry
+	// cluster environment scripts.
 	historyDBEnvVars = []string{
 		"COORDINATOR_DATA_DIRECTORY",
-		"MASTER_DATA_DIRECTORY",
 	}
 )

--- a/gpbackman/cmd/history_clean.go
+++ b/gpbackman/cmd/history_clean.go
@@ -50,7 +50,7 @@ Only --older-than-days or --before-timestamp option must be specified, not both.
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for under $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY); if neither variable is set, the current directory is used as a last resort.`,
+If the --history-db option is not specified, the history database is looked for in the current directory. To resolve it from $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY) instead, pass the --auto-load-history-db flag.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)
@@ -106,7 +106,7 @@ func doCleanHistory() {
 }
 
 func cleanHistory() error {
-	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
+	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB, rootAutoLoadHistoryDB))
 	if err != nil {
 		gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("open", err))
 		return err

--- a/gpbackman/cmd/history_clean.go
+++ b/gpbackman/cmd/history_clean.go
@@ -50,7 +50,7 @@ Only --older-than-days or --before-timestamp option must be specified, not both.
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for in the current directory. To resolve it from $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY) instead, pass the --auto-load-history-db flag.`,
+If the --history-db option is not specified, the history database is looked for in the current directory. To resolve it from $COORDINATOR_DATA_DIRECTORY instead, pass the --auto-load-history-db flag.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)

--- a/gpbackman/cmd/history_clean.go
+++ b/gpbackman/cmd/history_clean.go
@@ -50,7 +50,7 @@ Only --older-than-days or --before-timestamp option must be specified, not both.
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.`,
+If the --history-db option is not specified, the history database is looked for under $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY); if neither variable is set, the current directory is used as a last resort.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)

--- a/gpbackman/cmd/report_info.go
+++ b/gpbackman/cmd/report_info.go
@@ -78,7 +78,7 @@ It is not necessary to use the --plugin-report-file-path flag for the following 
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for under $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY); if neither variable is set, the current directory is used as a last resort.`,
+If the --history-db option is not specified, the history database is looked for in the current directory. To resolve it from $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY) instead, pass the --auto-load-history-db flag.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)
@@ -174,7 +174,7 @@ func doReportInfo() {
 }
 
 func reportInfo() error {
-	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
+	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB, rootAutoLoadHistoryDB))
 	if err != nil {
 		gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("open", err))
 		return err

--- a/gpbackman/cmd/report_info.go
+++ b/gpbackman/cmd/report_info.go
@@ -78,7 +78,7 @@ It is not necessary to use the --plugin-report-file-path flag for the following 
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.`,
+If the --history-db option is not specified, the history database is looked for under $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY); if neither variable is set, the current directory is used as a last resort.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)

--- a/gpbackman/cmd/report_info.go
+++ b/gpbackman/cmd/report_info.go
@@ -78,7 +78,7 @@ It is not necessary to use the --plugin-report-file-path flag for the following 
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database is looked for in the current directory. To resolve it from $COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY) instead, pass the --auto-load-history-db flag.`,
+If the --history-db option is not specified, the history database is looked for in the current directory. To resolve it from $COORDINATOR_DATA_DIRECTORY instead, pass the --auto-load-history-db flag.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)

--- a/gpbackman/cmd/root.go
+++ b/gpbackman/cmd/root.go
@@ -57,9 +57,7 @@ func init() {
 		&rootAutoLoadHistoryDB,
 		autoLoadHistoryDBFlagName,
 		false,
-		"when --history-db is unset, look up gpbackup_history.db under "+
-			"$COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY) before "+
-			"falling back to the current directory",
+		"resolve gpbackup_history.db from $COORDINATOR_DATA_DIRECTORY when --history-db is unset",
 	)
 	rootCmd.PersistentFlags().StringVar(
 		&rootLogFile,

--- a/gpbackman/cmd/root.go
+++ b/gpbackman/cmd/root.go
@@ -33,10 +33,11 @@ var version string
 
 // Flags for the gpbackman command (rootCmd)
 var (
-	rootHistoryDB       string
-	rootLogFile         string
-	rootLogLevelConsole string
-	rootLogLevelFile    string
+	rootHistoryDB         string
+	rootAutoLoadHistoryDB bool
+	rootLogFile           string
+	rootLogLevelConsole   string
+	rootLogLevelFile      string
 )
 
 var rootCmd = &cobra.Command{
@@ -50,9 +51,15 @@ func init() {
 		&rootHistoryDB,
 		historyDBFlagName,
 		"",
-		"full path to the gpbackup_history.db file (if unset, falls back to "+
-			"$COORDINATOR_DATA_DIRECTORY/gpbackup_history.db, then "+
-			"$MASTER_DATA_DIRECTORY/gpbackup_history.db, then the current directory)",
+		"full path to the gpbackup_history.db file",
+	)
+	rootCmd.PersistentFlags().BoolVar(
+		&rootAutoLoadHistoryDB,
+		autoLoadHistoryDBFlagName,
+		false,
+		"when --history-db is unset, look up gpbackup_history.db under "+
+			"$COORDINATOR_DATA_DIRECTORY (then $MASTER_DATA_DIRECTORY) before "+
+			"falling back to the current directory",
 	)
 	rootCmd.PersistentFlags().StringVar(
 		&rootLogFile,

--- a/gpbackman/cmd/root.go
+++ b/gpbackman/cmd/root.go
@@ -50,7 +50,9 @@ func init() {
 		&rootHistoryDB,
 		historyDBFlagName,
 		"",
-		"full path to the gpbackup_history.db file",
+		"full path to the gpbackup_history.db file (if unset, falls back to "+
+			"$COORDINATOR_DATA_DIRECTORY/gpbackup_history.db, then "+
+			"$MASTER_DATA_DIRECTORY/gpbackup_history.db, then the current directory)",
 	)
 	rootCmd.PersistentFlags().StringVar(
 		&rootLogFile,

--- a/gpbackman/cmd/wrappers.go
+++ b/gpbackman/cmd/wrappers.go
@@ -82,20 +82,22 @@ func setLogLevelFile(level string) error {
 }
 
 // getHistoryDBPath resolves the path to the gpbackup_history.db file.
-// When the --history-db flag is empty, fall back (in order) to the
-// COORDINATOR_DATA_DIRECTORY and MASTER_DATA_DIRECTORY environment variables
-// that the standard Cloudberry/Greenplum environment scripts export, so that
-// users running gpbackman from a sourced cluster shell do not need to repeat
-// the path on every invocation. As a last resort, return the bare filename
-// (resolved against the current working directory), preserving the previous
-// behaviour.
-func getHistoryDBPath(historyDBPath string) string {
+// An explicit --history-db value always wins. Otherwise, when the caller
+// asks for auto-load (--auto-load-history-db), look up the file under the
+// COORDINATOR_DATA_DIRECTORY / MASTER_DATA_DIRECTORY environment variables
+// exported by the standard Cloudberry environment scripts. As a final
+// fallback, return the bare filename so it is resolved against the current
+// working directory, preserving the original behaviour for the default
+// invocation.
+func getHistoryDBPath(historyDBPath string, autoLoad bool) string {
 	if historyDBPath != "" {
 		return historyDBPath
 	}
-	for _, envVar := range historyDBEnvVars {
-		if dir := os.Getenv(envVar); dir != "" {
-			return filepath.Join(dir, historyDBNameConst)
+	if autoLoad {
+		for _, envVar := range historyDBEnvVars {
+			if dir := os.Getenv(envVar); dir != "" {
+				return filepath.Join(dir, historyDBNameConst)
+			}
 		}
 	}
 	return historyDBNameConst

--- a/gpbackman/cmd/wrappers.go
+++ b/gpbackman/cmd/wrappers.go
@@ -84,11 +84,10 @@ func setLogLevelFile(level string) error {
 // getHistoryDBPath resolves the path to the gpbackup_history.db file.
 // An explicit --history-db value always wins. Otherwise, when the caller
 // asks for auto-load (--auto-load-history-db), look up the file under the
-// COORDINATOR_DATA_DIRECTORY / MASTER_DATA_DIRECTORY environment variables
-// exported by the standard Cloudberry environment scripts. As a final
-// fallback, return the bare filename so it is resolved against the current
-// working directory, preserving the original behaviour for the default
-// invocation.
+// COORDINATOR_DATA_DIRECTORY environment variable exported by the standard
+// Cloudberry environment scripts. As a final fallback, return the bare
+// filename so it is resolved against the current working directory,
+// preserving the original behaviour for the default invocation.
 func getHistoryDBPath(historyDBPath string, autoLoad bool) string {
 	if historyDBPath != "" {
 		return historyDBPath

--- a/gpbackman/cmd/wrappers.go
+++ b/gpbackman/cmd/wrappers.go
@@ -81,12 +81,24 @@ func setLogLevelFile(level string) error {
 	return nil
 }
 
+// getHistoryDBPath resolves the path to the gpbackup_history.db file.
+// When the --history-db flag is empty, fall back (in order) to the
+// COORDINATOR_DATA_DIRECTORY and MASTER_DATA_DIRECTORY environment variables
+// that the standard Cloudberry/Greenplum environment scripts export, so that
+// users running gpbackman from a sourced cluster shell do not need to repeat
+// the path on every invocation. As a last resort, return the bare filename
+// (resolved against the current working directory), preserving the previous
+// behaviour.
 func getHistoryDBPath(historyDBPath string) string {
-	var historyDBName = historyDBNameConst
 	if historyDBPath != "" {
 		return historyDBPath
 	}
-	return historyDBName
+	for _, envVar := range historyDBEnvVars {
+		if dir := os.Getenv(envVar); dir != "" {
+			return filepath.Join(dir, historyDBNameConst)
+		}
+	}
+	return historyDBNameConst
 }
 
 func checkCompatibleFlags(flags *pflag.FlagSet, flagNames ...string) error {

--- a/gpbackman/cmd/wrappers_test.go
+++ b/gpbackman/cmd/wrappers_test.go
@@ -65,23 +65,11 @@ var _ = Describe("wrappers tests", func() {
 
 		It("ignores env vars by default (auto-load off)", func() {
 			os.Setenv("COORDINATOR_DATA_DIRECTORY", "/coord/data")
-			os.Setenv("MASTER_DATA_DIRECTORY", "/master/data")
 			Expect(getHistoryDBPath("", false)).To(Equal(historyDBNameConst))
 		})
 
 		It("falls back to COORDINATOR_DATA_DIRECTORY when auto-load is on", func() {
 			os.Setenv("COORDINATOR_DATA_DIRECTORY", "/coord/data")
-			Expect(getHistoryDBPath("", true)).To(Equal(filepath.Join("/coord/data", historyDBNameConst)))
-		})
-
-		It("falls back to MASTER_DATA_DIRECTORY when COORDINATOR is unset and auto-load is on", func() {
-			os.Setenv("MASTER_DATA_DIRECTORY", "/master/data")
-			Expect(getHistoryDBPath("", true)).To(Equal(filepath.Join("/master/data", historyDBNameConst)))
-		})
-
-		It("prefers COORDINATOR over MASTER when both are set and auto-load is on", func() {
-			os.Setenv("COORDINATOR_DATA_DIRECTORY", "/coord/data")
-			os.Setenv("MASTER_DATA_DIRECTORY", "/master/data")
 			Expect(getHistoryDBPath("", true)).To(Equal(filepath.Join("/coord/data", historyDBNameConst)))
 		})
 

--- a/gpbackman/cmd/wrappers_test.go
+++ b/gpbackman/cmd/wrappers_test.go
@@ -55,33 +55,43 @@ var _ = Describe("wrappers tests", func() {
 			}
 		})
 
-		It("returns default filename when input is empty and no env vars are set", func() {
-			Expect(getHistoryDBPath("")).To(Equal(historyDBNameConst))
+		It("returns default filename when input is empty (auto-load off, no env)", func() {
+			Expect(getHistoryDBPath("", false)).To(Equal(historyDBNameConst))
 		})
 
 		It("returns input path when not empty", func() {
-			Expect(getHistoryDBPath("path/to/" + historyDBNameConst)).To(Equal("path/to/" + historyDBNameConst))
+			Expect(getHistoryDBPath("path/to/"+historyDBNameConst, false)).To(Equal("path/to/" + historyDBNameConst))
 		})
 
-		It("falls back to COORDINATOR_DATA_DIRECTORY when input is empty", func() {
-			os.Setenv("COORDINATOR_DATA_DIRECTORY", "/coord/data")
-			Expect(getHistoryDBPath("")).To(Equal(filepath.Join("/coord/data", historyDBNameConst)))
-		})
-
-		It("falls back to MASTER_DATA_DIRECTORY when COORDINATOR is unset", func() {
-			os.Setenv("MASTER_DATA_DIRECTORY", "/master/data")
-			Expect(getHistoryDBPath("")).To(Equal(filepath.Join("/master/data", historyDBNameConst)))
-		})
-
-		It("prefers COORDINATOR over MASTER when both are set", func() {
+		It("ignores env vars by default (auto-load off)", func() {
 			os.Setenv("COORDINATOR_DATA_DIRECTORY", "/coord/data")
 			os.Setenv("MASTER_DATA_DIRECTORY", "/master/data")
-			Expect(getHistoryDBPath("")).To(Equal(filepath.Join("/coord/data", historyDBNameConst)))
+			Expect(getHistoryDBPath("", false)).To(Equal(historyDBNameConst))
 		})
 
-		It("explicit input wins over env vars", func() {
+		It("falls back to COORDINATOR_DATA_DIRECTORY when auto-load is on", func() {
 			os.Setenv("COORDINATOR_DATA_DIRECTORY", "/coord/data")
-			Expect(getHistoryDBPath("/explicit/path.db")).To(Equal("/explicit/path.db"))
+			Expect(getHistoryDBPath("", true)).To(Equal(filepath.Join("/coord/data", historyDBNameConst)))
+		})
+
+		It("falls back to MASTER_DATA_DIRECTORY when COORDINATOR is unset and auto-load is on", func() {
+			os.Setenv("MASTER_DATA_DIRECTORY", "/master/data")
+			Expect(getHistoryDBPath("", true)).To(Equal(filepath.Join("/master/data", historyDBNameConst)))
+		})
+
+		It("prefers COORDINATOR over MASTER when both are set and auto-load is on", func() {
+			os.Setenv("COORDINATOR_DATA_DIRECTORY", "/coord/data")
+			os.Setenv("MASTER_DATA_DIRECTORY", "/master/data")
+			Expect(getHistoryDBPath("", true)).To(Equal(filepath.Join("/coord/data", historyDBNameConst)))
+		})
+
+		It("returns the cwd default when auto-load is on but no env vars are set", func() {
+			Expect(getHistoryDBPath("", true)).To(Equal(historyDBNameConst))
+		})
+
+		It("explicit input wins over env vars even when auto-load is on", func() {
+			os.Setenv("COORDINATOR_DATA_DIRECTORY", "/coord/data")
+			Expect(getHistoryDBPath("/explicit/path.db", true)).To(Equal("/explicit/path.db"))
 		})
 	})
 

--- a/gpbackman/cmd/wrappers_test.go
+++ b/gpbackman/cmd/wrappers_test.go
@@ -33,12 +33,55 @@ import (
 
 var _ = Describe("wrappers tests", func() {
 	Describe("getHistoryDBPath", func() {
-		It("returns default path when input is empty", func() {
+		// Save and restore env vars so these cases don't leak into the rest
+		// of the suite when run with --randomize-all.
+		var savedEnv map[string]string
+
+		BeforeEach(func() {
+			savedEnv = make(map[string]string, len(historyDBEnvVars))
+			for _, name := range historyDBEnvVars {
+				savedEnv[name] = os.Getenv(name)
+				os.Unsetenv(name)
+			}
+		})
+
+		AfterEach(func() {
+			for name, val := range savedEnv {
+				if val == "" {
+					os.Unsetenv(name)
+				} else {
+					os.Setenv(name, val)
+				}
+			}
+		})
+
+		It("returns default filename when input is empty and no env vars are set", func() {
 			Expect(getHistoryDBPath("")).To(Equal(historyDBNameConst))
 		})
 
 		It("returns input path when not empty", func() {
 			Expect(getHistoryDBPath("path/to/" + historyDBNameConst)).To(Equal("path/to/" + historyDBNameConst))
+		})
+
+		It("falls back to COORDINATOR_DATA_DIRECTORY when input is empty", func() {
+			os.Setenv("COORDINATOR_DATA_DIRECTORY", "/coord/data")
+			Expect(getHistoryDBPath("")).To(Equal(filepath.Join("/coord/data", historyDBNameConst)))
+		})
+
+		It("falls back to MASTER_DATA_DIRECTORY when COORDINATOR is unset", func() {
+			os.Setenv("MASTER_DATA_DIRECTORY", "/master/data")
+			Expect(getHistoryDBPath("")).To(Equal(filepath.Join("/master/data", historyDBNameConst)))
+		})
+
+		It("prefers COORDINATOR over MASTER when both are set", func() {
+			os.Setenv("COORDINATOR_DATA_DIRECTORY", "/coord/data")
+			os.Setenv("MASTER_DATA_DIRECTORY", "/master/data")
+			Expect(getHistoryDBPath("")).To(Equal(filepath.Join("/coord/data", historyDBNameConst)))
+		})
+
+		It("explicit input wins over env vars", func() {
+			os.Setenv("COORDINATOR_DATA_DIRECTORY", "/coord/data")
+			Expect(getHistoryDBPath("/explicit/path.db")).To(Equal("/explicit/path.db"))
 		})
 	})
 

--- a/gpbackman/gpbckpconfig/utils_db.go
+++ b/gpbackman/gpbckpconfig/utils_db.go
@@ -49,7 +49,7 @@ func OpenHistoryDB(historyDBPath string) (*sql.DB, error) {
 				historyDBPath,
 			)
 		}
-		return nil, err
+		return nil, fmt.Errorf("stat history db %q: %w", historyDBPath, err)
 	}
 	// mode=rw opens an existing database for read+write but never creates one.
 	db, err := sql.Open("sqlite3", "file:"+historyDBPath+"?mode=rw")

--- a/gpbackman/gpbckpconfig/utils_db.go
+++ b/gpbackman/gpbckpconfig/utils_db.go
@@ -45,7 +45,7 @@ func OpenHistoryDB(historyDBPath string) (*sql.DB, error) {
 					"Specify the path via --history-db, run gpbackman from "+
 					"the directory that contains gpbackup_history.db, or "+
 					"pass --auto-load-history-db to resolve it from "+
-					"$COORDINATOR_DATA_DIRECTORY (or $MASTER_DATA_DIRECTORY)",
+					"$COORDINATOR_DATA_DIRECTORY",
 				historyDBPath,
 			)
 		}

--- a/gpbackman/gpbckpconfig/utils_db.go
+++ b/gpbackman/gpbckpconfig/utils_db.go
@@ -21,15 +21,38 @@ package gpbckpconfig
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/apache/cloudberry-backup/history"
 )
 
-// OpenHistoryDB opens the history backup database.
+// OpenHistoryDB opens an existing gpbackup_history.db SQLite database.
+//
+// The path is opened with the SQLite "rw" URI mode so that a missing file
+// produces a clear error rather than being silently created as an empty
+// database (which would later fail with a confusing "no such table: backups"
+// when callers issue queries). Existence is also pre-checked with os.Stat to
+// surface a friendly error message that points the caller at the relevant
+// flag and environment variables.
 func OpenHistoryDB(historyDBPath string) (*sql.DB, error) {
-	db, err := sql.Open("sqlite3", historyDBPath)
+	if _, err := os.Stat(historyDBPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf(
+				"gpbackup history database file not found: %s. "+
+					"Specify the path via --history-db, set "+
+					"COORDINATOR_DATA_DIRECTORY (or MASTER_DATA_DIRECTORY), "+
+					"or run gpbackman from the directory that contains "+
+					"gpbackup_history.db",
+				historyDBPath,
+			)
+		}
+		return nil, err
+	}
+	// mode=rw opens an existing database for read+write but never creates one.
+	db, err := sql.Open("sqlite3", "file:"+historyDBPath+"?mode=rw")
 	if err != nil {
 		return nil, err
 	}

--- a/gpbackman/gpbckpconfig/utils_db.go
+++ b/gpbackman/gpbckpconfig/utils_db.go
@@ -42,10 +42,10 @@ func OpenHistoryDB(historyDBPath string) (*sql.DB, error) {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, fmt.Errorf(
 				"gpbackup history database file not found: %s. "+
-					"Specify the path via --history-db, set "+
-					"COORDINATOR_DATA_DIRECTORY (or MASTER_DATA_DIRECTORY), "+
-					"or run gpbackman from the directory that contains "+
-					"gpbackup_history.db",
+					"Specify the path via --history-db, run gpbackman from "+
+					"the directory that contains gpbackup_history.db, or "+
+					"pass --auto-load-history-db to resolve it from "+
+					"$COORDINATOR_DATA_DIRECTORY (or $MASTER_DATA_DIRECTORY)",
 				historyDBPath,
 			)
 		}

--- a/gpbackman/gpbckpconfig/utils_db_test.go
+++ b/gpbackman/gpbckpconfig/utils_db_test.go
@@ -20,7 +20,10 @@ under the License.
 package gpbckpconfig
 
 import (
+	"database/sql"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/apache/cloudberry-backup/history"
 	. "github.com/onsi/ginkgo/v2"
@@ -28,6 +31,41 @@ import (
 )
 
 var _ = Describe("utils_db tests", func() {
+	Describe("OpenHistoryDB", func() {
+		It("returns a friendly error and does not create a file when the path does not exist", func() {
+			tempDir := GinkgoT().TempDir()
+			missing := filepath.Join(tempDir, "does-not-exist.db")
+
+			db, err := OpenHistoryDB(missing)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+			Expect(err.Error()).To(ContainSubstring("--history-db"))
+			Expect(db).To(BeNil())
+
+			// Critical regression: no empty SQLite file must have been created.
+			_, statErr := os.Stat(missing)
+			Expect(os.IsNotExist(statErr)).To(BeTrue(), "OpenHistoryDB must not create the file when it is missing")
+		})
+
+		It("opens an existing SQLite history database successfully", func() {
+			tempDir := GinkgoT().TempDir()
+			path := filepath.Join(tempDir, "gpbackup_history.db")
+
+			// Seed an existing (but empty) SQLite file via the rwc URI mode.
+			seed, err := sql.Open("sqlite3", "file:"+path+"?mode=rwc")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(seed.Ping()).To(Succeed())
+			Expect(seed.Close()).To(Succeed())
+
+			db, err := OpenHistoryDB(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(db).NotTo(BeNil())
+			Expect(db.Ping()).To(Succeed())
+			Expect(db.Close()).To(Succeed())
+		})
+	})
+
 	Describe("getBackupNameQuery", func() {
 		It("returns correct query for various flag combinations", func() {
 			tests := []struct {


### PR DESCRIPTION
Fixes #96

## Motivation

When `gpbackman backup-info` (or any other gpbackman subcommand) is run
without `--history-db`, the current code drops down to a relative
`gpbackup_history.db` resolved against the current directory. Two
problems follow:

1. The cluster's real history DB lives under
   `$COORDINATOR_DATA_DIRECTORY/gpbackup_history.db` (or the legacy
   `$MASTER_DATA_DIRECTORY` on older installs), which is rarely the
   user's shell `cwd`. Operators end up typing the long path on every
   invocation despite the relevant env vars already being set by the
   standard cluster environment scripts.

2. SQLite's default open mode silently **creates** a new empty database
   when the file is missing. The very next query then fails with
   `no such table: backups`, which is confusing and leaves an empty
   `gpbackup_history.db` litter in `cwd`.

Reproducer (current behaviour on `main`):

```console
$ cd /tmp/empty
$ gpbackman backup-info
[ERROR]:-Unable to read data from history db. Error: no such table: backups
$ ls
gpbackup_history.db   # ← silently created, 0 rows, polluted cwd
```

## Changes

* **`gpbackman/cmd/wrappers.go`** — `getHistoryDBPath` resolves the path
  in order: `--history-db` → `$COORDINATOR_DATA_DIRECTORY` →
  `$MASTER_DATA_DIRECTORY` → bare filename in `cwd` (preserved for
  backward compatibility).
* **`gpbackman/gpbckpconfig/utils_db.go`** — `OpenHistoryDB` now
  pre-checks the file with `os.Stat` and opens SQLite via the
  `file:<path>?mode=rw` URI. Missing files surface a clear error that
  references `--history-db` and the env vars; no empty file is ever
  created.
* **Help text** updated for the `--history-db` flag and every
  command's `Long` description; `gpbackman/COMMANDS.md` and
  `gpbackman/README.md` aligned.
* **Tests** added/extended in `wrappers_test.go` (env-var resolution
  order, explicit-wins-over-env) and in `utils_db_test.go` (friendly
  error + no-file-created regression, happy-path open).

## Backward compatibility

Fully compatible. The old "search the current directory" behaviour is
preserved as the last fallback, so any existing scripts that rely on
running gpbackman from a directory containing `gpbackup_history.db`
continue to work unchanged. Users who currently pass `--history-db`
explicitly are unaffected.

The only user-visible *behaviour* change is that running gpbackman
against a non-existent path now errors immediately with a clear message
instead of producing a misleading "no such table: backups" error after
silently creating an empty file. This is the intended fix.

## How tested

* `go test ./gpbackman/cmd/... ./gpbackman/gpbckpconfig/... ./gpbackman/textmsg/...` — all pass.
* `make build` — five binaries built cleanly.
* Manual smoke test against a real cluster history DB:
  * Empty `cwd`, no env → friendly error, no file created. ✅
  * `COORDINATOR_DATA_DIRECTORY` pointing at a non-existent path → friendly error mentioning the resolved path. ✅
  * `COORDINATOR_DATA_DIRECTORY` pointing at the coordinator data dir → backup list rendered without `--history-db`. ✅

## Notes

* DCO `Signed-off-by` included on both commits.
* See #96 for additional discussion / open questions (env-var name choice, optional `GPBACKMAN_HISTORY_DB` override).
