### PR TITLE
feat(backup): file-hash incremental detection for heap and AO tables

### DIFF
--- a/backup/incremental.go
+++ b/backup/incremental.go
@@ -13,17 +13,67 @@ import (
 	"github.com/pkg/errors"
 )
 
+// FilterTablesForIncremental decides which tables need data backed up.
+//
+// Independent toggles:
+//   - AO:   default = modcount + DDL timestamp; with --ao-file-hash, use per-table aoseg content hash
+//   - Heap: default = always include (original gpbackup behavior); with --heap-file-hash, skip unchanged via file hash
 func FilterTablesForIncremental(lastBackupTOC, currentTOC *toc.TOC, tables []Table) []Table {
+	useAOHash := MustGetFlagBool(options.AO_FILE_HASH)
+	useHeapHash := MustGetFlagBool(options.HEAP_FILE_HASH)
+
 	var filteredTables []Table
 	for _, table := range tables {
-		currentAOEntry, isAOTable := currentTOC.IncrementalMetadata.AO[table.FQN()]
-		if !isAOTable {
+		fqn := table.FQN()
+
+		if currentAO, isAO := currentTOC.IncrementalMetadata.AO[fqn]; isAO {
+			if useAOHash && currentAO.FileHashMD5 != "" {
+				prevAO, hasPrev := lastBackupTOC.IncrementalMetadata.AO[fqn]
+				if !hasPrev || prevAO.FileHashMD5 == "" {
+					gplog.Debug("Filter: %s (AO/content) prev hash missing, including", fqn)
+					filteredTables = append(filteredTables, table)
+					continue
+				}
+				if prevAO.FileHashMD5 != currentAO.FileHashMD5 {
+					filteredTables = append(filteredTables, table)
+				}
+			} else {
+				prevAO := lastBackupTOC.IncrementalMetadata.AO[fqn]
+				if prevAO.Modcount != currentAO.Modcount || prevAO.LastDDLTimestamp != currentAO.LastDDLTimestamp {
+					filteredTables = append(filteredTables, table)
+				}
+			}
+			continue
+		}
+
+		if !useHeapHash {
+			// Original behavior: heap tables always included in incremental
 			filteredTables = append(filteredTables, table)
 			continue
 		}
-		previousAOEntry := lastBackupTOC.IncrementalMetadata.AO[table.FQN()]
 
-		if previousAOEntry.Modcount != currentAOEntry.Modcount || previousAOEntry.LastDDLTimestamp != currentAOEntry.LastDDLTimestamp {
+		// --heap-file-hash: skip heap tables whose file hash is unchanged
+		if currentTOC.IncrementalMetadata.Heap == nil {
+			filteredTables = append(filteredTables, table)
+			continue
+		}
+		currentHeap, isHeap := currentTOC.IncrementalMetadata.Heap[fqn]
+		if !isHeap || currentHeap.FileHashMD5 == "" {
+			gplog.Debug("Filter: %s (Heap) no current hash, including", fqn)
+			filteredTables = append(filteredTables, table)
+			continue
+		}
+		if lastBackupTOC.IncrementalMetadata.Heap == nil {
+			filteredTables = append(filteredTables, table)
+			continue
+		}
+		prevHeap, hasPrev := lastBackupTOC.IncrementalMetadata.Heap[fqn]
+		if !hasPrev || prevHeap.FileHashMD5 == "" {
+			gplog.Debug("Filter: %s (Heap) prev hash missing, including", fqn)
+			filteredTables = append(filteredTables, table)
+			continue
+		}
+		if prevHeap.FileHashMD5 != currentHeap.FileHashMD5 {
 			filteredTables = append(filteredTables, table)
 		}
 	}

--- a/backup/incremental_test.go
+++ b/backup/incremental_test.go
@@ -61,7 +61,12 @@ var _ = Describe("backup/incremental tests", func() {
 			tblAOUnchanged,
 		}
 
-		filteredTables := backup.FilterTablesForIncremental(&prevTOC, &currTOC, tables)
+		// FilterTablesForIncremental reads --ao-file-hash / --heap-file-hash flags via MustGetFlagBool,
+		// so the call must happen after BeforeSuite initializes cmdFlags — i.e. inside a leaf node.
+		var filteredTables []backup.Table
+		JustBeforeEach(func() {
+			filteredTables = backup.FilterTablesForIncremental(&prevTOC, &currTOC, tables)
+		})
 
 		It("Should include the heap table in the filtered list", func() {
 			Expect(filteredTables).To(ContainElement(tblHeap))

--- a/backup/queries_incremental.go
+++ b/backup/queries_incremental.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/apache/cloudberry-backup/toc"
 	"github.com/apache/cloudberry-go-libs/dbconn"
@@ -175,4 +176,243 @@ func getLastDDLTimestamps(connectionPool *dbconn.DBConn) map[string]string {
 		resultMap[result.AOTableFQN] = result.LastDDLTimestamp
 	}
 	return resultMap
+}
+
+// getFileHashesForTables collects file timestamp+size MD5 hashes for a list of tables
+// using the provided connection. The connection must be reused across all tables
+// to ensure consistent gp_segment_id mapping.
+func getFileHashesForTables(hashConn *dbconn.DBConn, tableFQNs []string) map[string]string {
+	result := make(map[string]string)
+	for _, fqn := range tableFQNs {
+		hash := getTableFileHash(hashConn, fqn)
+		if hash != "" {
+			result[fqn] = hash
+		}
+	}
+	return result
+}
+
+// ensureFileStatFunction creates a plpgsql function (gp_toolkit.gpbackup_file_info)
+// that uses pg_stat_file() to read each segment's data-file mtime+size. Pure SQL,
+// no plpython/shell. Uses a separate connection so a failed setup does not abort
+// the backup transaction.
+func ensureFileStatFunction(connectionPool *dbconn.DBConn) bool {
+	gplog.Verbose("Setting up file hash detection function (plpgsql + pg_stat_file)")
+
+	setupConn := dbconn.NewDBConnFromEnvironment(connectionPool.DBName)
+	setupConn.MustConnect(1)
+	defer setupConn.Close()
+
+	checkSQL := `SELECT 1 AS val FROM pg_proc
+		WHERE proname = 'gpbackup_file_info'
+		AND pronamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'gp_toolkit');`
+	var checkResult []struct{ Val int }
+	err := setupConn.Select(&checkResult, checkSQL)
+
+	if err != nil || len(checkResult) == 0 {
+		gplog.Verbose("Creating gp_toolkit.gpbackup_file_info function")
+
+		createSQL := `
+CREATE OR REPLACE FUNCTION gp_toolkit.gpbackup_file_info(p_schema text, p_table text)
+RETURNS text AS $BODY$
+DECLARE
+    v_tsp  oid;
+    v_rfn  oid;
+    v_dboid oid;
+    v_dbtsp oid;
+    v_path text;
+    v_mod  text;
+    v_size text;
+BEGIN
+    SELECT c.reltablespace, c.relfilenode INTO v_tsp, v_rfn
+    FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid
+    WHERE n.nspname = p_schema AND c.relname = p_table;
+
+    IF v_rfn IS NULL THEN
+        RETURN '';
+    END IF;
+
+    SELECT oid, dattablespace INTO v_dboid, v_dbtsp
+    FROM pg_database WHERE datname = current_database();
+
+    IF v_tsp = 0 THEN
+        v_tsp := v_dbtsp;
+    END IF;
+
+    IF v_tsp = 1663 THEN
+        v_path := 'base/' || v_dboid || '/' || v_rfn;
+    ELSE
+        v_path := 'pg_tblspc/' || v_tsp || '/' || v_dboid || '/' || v_rfn;
+    END IF;
+
+    BEGIN
+        SELECT (pg_stat_file(v_path)).modification::text,
+               (pg_stat_file(v_path)).size::text
+        INTO v_mod, v_size;
+    EXCEPTION WHEN OTHERS THEN
+        v_mod := '';
+        v_size := '0';
+    END;
+
+    RETURN COALESCE(v_mod, '') || '|' || COALESCE(v_size, '0');
+END;
+$BODY$ LANGUAGE plpgsql;`
+
+		_, createErr := setupConn.Exec(createSQL, 0)
+		if createErr != nil {
+			gplog.Warn("Could not create gpbackup_file_info function: %v", createErr)
+			return false
+		}
+		gplog.Verbose("gpbackup_file_info function created successfully")
+	}
+
+	return true
+}
+
+// getHeapTableFQNs returns FQNs of heap tables eligible for incremental backup.
+func getHeapTableFQNs(connectionPool *dbconn.DBConn) []string {
+	var query string
+	if connectionPool.Version.IsGPDB() && connectionPool.Version.Before("7") {
+		query = fmt.Sprintf(`
+			SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS tablefqn
+			FROM pg_class c
+			JOIN pg_namespace n ON c.relnamespace = n.oid
+			WHERE c.relstorage = 'h'
+			AND c.relkind = 'r'
+			AND c.oid NOT IN (SELECT inhrelid FROM pg_inherits)
+			AND %s`, relationAndSchemaFilterClause())
+	} else {
+		query = fmt.Sprintf(`
+			SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS tablefqn
+			FROM pg_class c
+			JOIN pg_namespace n ON c.relnamespace = n.oid
+			JOIN pg_am a ON c.relam = a.oid
+			WHERE a.amname = 'heap'
+			AND c.relkind = 'r'
+			AND c.oid NOT IN (SELECT inhrelid FROM pg_inherits)
+			AND %s`, relationAndSchemaFilterClause())
+	}
+
+	var results []struct{ TableFQN string }
+	err := connectionPool.Select(&results, query)
+	gplog.FatalOnError(err)
+	fqns := make([]string, len(results))
+	for i, r := range results {
+		fqns[i] = r.TableFQN
+	}
+	return fqns
+}
+
+// getTableFileHash computes an MD5 hash of per-segment data-file mtime+size for a
+// heap table, using gp_toolkit.gpbackup_file_info (plpgsql + pg_stat_file).
+// gp_dist_random('gp_id') runs the function locally on each segment.
+func getTableFileHash(hashConn *dbconn.DBConn, tableFQN string) string {
+	parts := splitFQN(tableFQN)
+	if len(parts) != 2 {
+		return ""
+	}
+	schema, table := parts[0], parts[1]
+
+	query := fmt.Sprintf(`
+		SELECT COALESCE(md5(string_agg(
+			gp_segment_id::text || ',' || info, chr(10) ORDER BY gp_segment_id
+		)), '') AS filehash
+		FROM (
+			SELECT gp_segment_id,
+				gp_toolkit.gpbackup_file_info('%s', '%s') AS info
+			FROM gp_dist_random('gp_id')
+		) x
+		WHERE info <> ''`,
+		schema, table)
+
+	var results []struct{ FileHash string }
+	err := hashConn.Select(&results, query)
+	if err != nil {
+		gplog.Warn("Could not get file hash for %s: %v", tableFQN, err)
+		return ""
+	}
+	if len(results) == 0 || results[0].FileHash == "" {
+		return ""
+	}
+	return results[0].FileHash
+}
+
+// splitFQN splits "schema.table" into [schema, table], stripping quote chars.
+func splitFQN(fqn string) []string {
+	fqn = strings.ReplaceAll(fqn, "\"", "")
+	parts := strings.SplitN(fqn, ".", 2)
+	return parts
+}
+
+// GetAOContentHashes returns a per-table aoseg content hash for every AO/AOCS table.
+// In GP5, parent modcount changes when any child partition is modified, but each
+// child's aoseg table only changes when that specific child receives data — so
+// hashing the aoseg rows gives partition-level granularity.
+// Uses a dedicated connection to avoid transaction abort propagation.
+func GetAOContentHashes(connectionPool *dbconn.DBConn) map[string]string {
+	segTableFQNs := getAOSegTableFQNs(connectionPool)
+
+	hashConn := dbconn.NewDBConnFromEnvironment(connectionPool.DBName)
+	hashConn.MustConnect(1)
+	defer hashConn.Close()
+
+	result := make(map[string]string)
+	for aoTableFQN, aosegTableFQN := range segTableFQNs {
+		hash := getAOSegContentHash(hashConn, aosegTableFQN)
+		if hash != "" {
+			result[aoTableFQN] = hash
+		}
+	}
+	return result
+}
+
+// getAOSegContentHash hashes content-bearing columns of the aoseg metadata table —
+// deliberately excluding modcount, which in GP5 propagates across sibling partitions
+// even when only one is modified.
+//
+//   - AO row (pg_aoseg_*): segno + eof + tupcount.
+//   - AOCS column store (pg_aocsseg_*): layout differs by product / version.
+//     Cloudberry AOCS exposes vpinfo (vertical-partition info, a bytea containing
+//     per-column eofs); GP7+ exposes column_num + physical_segno + eof_uncompressed;
+//     pre-GP6 only has segno + tupcount.
+func getAOSegContentHash(hashConn *dbconn.DBConn, aosegTableFQN string) string {
+	isColumnStore := strings.Contains(aosegTableFQN, "pg_aocsseg")
+
+	var cols string
+	if isColumnStore {
+		switch {
+		case !hashConn.Version.IsGPDB():
+			// Cloudberry AOCS: segno, tupcount, vpinfo (bytea with per-column EOFs)
+			cols = "segno::text || ',' || tupcount::text || ',' || encode(vpinfo, 'hex')"
+		case hashConn.Version.Before("6"):
+			cols = "segno::text || ',' || tupcount::text"
+		default:
+			// GP7+ AOCS
+			cols = "segno::text || ',' || column_num::text || ',' || physical_segno::text || ',' || tupcount::text || ',' || eof_uncompressed::text"
+		}
+	} else {
+		cols = "segno::text || ',' || eof::text || ',' || tupcount::text"
+	}
+
+	var query string
+	if hashConn.Version.IsGPDB() && hashConn.Version.Before("7") {
+		query = fmt.Sprintf(`SELECT COALESCE(md5(string_agg(%s,
+			chr(10) ORDER BY segno)), '') AS contenthash FROM %s`, cols, aosegTableFQN)
+	} else {
+		query = fmt.Sprintf(`SELECT COALESCE(md5(string_agg(
+			gp_segment_id::text || ',' || %s,
+			chr(10) ORDER BY gp_segment_id, segno)), '') AS contenthash FROM gp_dist_random('%s')`,
+			cols, aosegTableFQN)
+	}
+
+	var results []struct{ ContentHash string }
+	err := hashConn.Select(&results, query)
+	if err != nil {
+		gplog.Warn("Could not get aoseg content hash for %s: %v", aosegTableFQN, err)
+		return ""
+	}
+	if len(results) == 0 {
+		return ""
+	}
+	return results[0].ContentHash
 }

--- a/backup/queries_incremental.go
+++ b/backup/queries_incremental.go
@@ -178,24 +178,39 @@ func getLastDDLTimestamps(connectionPool *dbconn.DBConn) map[string]string {
 	return resultMap
 }
 
-// getFileHashesForTables collects file timestamp+size MD5 hashes for a list of tables
-// using the provided connection. The connection must be reused across all tables
-// to ensure consistent gp_segment_id mapping.
-func getFileHashesForTables(hashConn *dbconn.DBConn, tableFQNs []string) map[string]string {
+// heapTable carries the catalog identity of a heap table eligible for file-hash
+// incremental backup. Oid is what we pass into the file-hash plpgsql function
+// (pg_relation_filepath resolves it locally on each segment); FQN is for keying
+// the result map and for log messages.
+type heapTable struct {
+	Oid uint32
+	FQN string
+}
+
+// getFileHashesForTables collects file timestamp+size MD5 hashes for the given
+// heap tables using the provided connection. The connection must be reused
+// across all tables so gp_segment_id mapping stays consistent.
+func getFileHashesForTables(hashConn *dbconn.DBConn, tables []heapTable) map[string]string {
 	result := make(map[string]string)
-	for _, fqn := range tableFQNs {
-		hash := getTableFileHash(hashConn, fqn)
+	for _, t := range tables {
+		hash := getTableFileHash(hashConn, t.Oid, t.FQN)
 		if hash != "" {
-			result[fqn] = hash
+			result[t.FQN] = hash
 		}
 	}
 	return result
 }
 
 // ensureFileStatFunction creates a plpgsql function (gp_toolkit.gpbackup_file_info)
-// that uses pg_stat_file() to read each segment's data-file mtime+size. Pure SQL,
-// no plpython/shell. Uses a separate connection so a failed setup does not abort
-// the backup transaction.
+// that uses pg_relation_filepath() + pg_stat_file() to read each segment's
+// data-file mtime+size. Pure SQL, no plpython/shell. Uses a separate connection
+// so a failed setup does not abort the backup transaction.
+//
+// pg_relation_filepath is used because manual path construction is fragile:
+// custom tablespaces live under pg_tblspc/<tsp>/PG_<major>_<catver>/<db>/<rfn>,
+// and that PG_<major>_<catver> segment varies by server version. Letting the
+// server compute the path keeps us correct across versions and tablespace
+// configurations.
 func ensureFileStatFunction(connectionPool *dbconn.DBConn) bool {
 	gplog.Verbose("Setting up file hash detection function (plpgsql + pg_stat_file)")
 
@@ -205,6 +220,7 @@ func ensureFileStatFunction(connectionPool *dbconn.DBConn) bool {
 
 	checkSQL := `SELECT 1 AS val FROM pg_proc
 		WHERE proname = 'gpbackup_file_info'
+		AND pronargs = 1
 		AND pronamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'gp_toolkit');`
 	var checkResult []struct{ Val int }
 	err := setupConn.Select(&checkResult, checkSQL)
@@ -212,37 +228,21 @@ func ensureFileStatFunction(connectionPool *dbconn.DBConn) bool {
 	if err != nil || len(checkResult) == 0 {
 		gplog.Verbose("Creating gp_toolkit.gpbackup_file_info function")
 
+		// Drop any older (text, text) signature from a previous gpbackup version
+		// before recreating with the new (oid) signature.
+		_, _ = setupConn.Exec("DROP FUNCTION IF EXISTS gp_toolkit.gpbackup_file_info(text, text);", 0)
+
 		createSQL := `
-CREATE OR REPLACE FUNCTION gp_toolkit.gpbackup_file_info(p_schema text, p_table text)
+CREATE OR REPLACE FUNCTION gp_toolkit.gpbackup_file_info(p_oid oid)
 RETURNS text AS $BODY$
 DECLARE
-    v_tsp  oid;
-    v_rfn  oid;
-    v_dboid oid;
-    v_dbtsp oid;
     v_path text;
     v_mod  text;
     v_size text;
 BEGIN
-    SELECT c.reltablespace, c.relfilenode INTO v_tsp, v_rfn
-    FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid
-    WHERE n.nspname = p_schema AND c.relname = p_table;
-
-    IF v_rfn IS NULL THEN
+    v_path := pg_relation_filepath(p_oid);
+    IF v_path IS NULL THEN
         RETURN '';
-    END IF;
-
-    SELECT oid, dattablespace INTO v_dboid, v_dbtsp
-    FROM pg_database WHERE datname = current_database();
-
-    IF v_tsp = 0 THEN
-        v_tsp := v_dbtsp;
-    END IF;
-
-    IF v_tsp = 1663 THEN
-        v_path := 'base/' || v_dboid || '/' || v_rfn;
-    ELSE
-        v_path := 'pg_tblspc/' || v_tsp || '/' || v_dboid || '/' || v_rfn;
     END IF;
 
     BEGIN
@@ -250,8 +250,7 @@ BEGIN
                (pg_stat_file(v_path)).size::text
         INTO v_mod, v_size;
     EXCEPTION WHEN OTHERS THEN
-        v_mod := '';
-        v_size := '0';
+        RETURN '';
     END;
 
     RETURN COALESCE(v_mod, '') || '|' || COALESCE(v_size, '0');
@@ -269,12 +268,13 @@ $BODY$ LANGUAGE plpgsql;`
 	return true
 }
 
-// getHeapTableFQNs returns FQNs of heap tables eligible for incremental backup.
-func getHeapTableFQNs(connectionPool *dbconn.DBConn) []string {
+// getHeapTables returns (oid, FQN) pairs of heap tables eligible for incremental backup.
+func getHeapTables(connectionPool *dbconn.DBConn) []heapTable {
 	var query string
 	if connectionPool.Version.IsGPDB() && connectionPool.Version.Before("7") {
 		query = fmt.Sprintf(`
-			SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS tablefqn
+			SELECT c.oid,
+				quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS tablefqn
 			FROM pg_class c
 			JOIN pg_namespace n ON c.relnamespace = n.oid
 			WHERE c.relstorage = 'h'
@@ -283,7 +283,8 @@ func getHeapTableFQNs(connectionPool *dbconn.DBConn) []string {
 			AND %s`, relationAndSchemaFilterClause())
 	} else {
 		query = fmt.Sprintf(`
-			SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS tablefqn
+			SELECT c.oid,
+				quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS tablefqn
 			FROM pg_class c
 			JOIN pg_namespace n ON c.relnamespace = n.oid
 			JOIN pg_am a ON c.relam = a.oid
@@ -293,55 +294,46 @@ func getHeapTableFQNs(connectionPool *dbconn.DBConn) []string {
 			AND %s`, relationAndSchemaFilterClause())
 	}
 
-	var results []struct{ TableFQN string }
+	var results []struct {
+		Oid      uint32
+		TableFQN string
+	}
 	err := connectionPool.Select(&results, query)
 	gplog.FatalOnError(err)
-	fqns := make([]string, len(results))
+	out := make([]heapTable, len(results))
 	for i, r := range results {
-		fqns[i] = r.TableFQN
+		out[i] = heapTable{Oid: r.Oid, FQN: r.TableFQN}
 	}
-	return fqns
+	return out
 }
 
-// getTableFileHash computes an MD5 hash of per-segment data-file mtime+size for a
-// heap table, using gp_toolkit.gpbackup_file_info (plpgsql + pg_stat_file).
-// gp_dist_random('gp_id') runs the function locally on each segment.
-func getTableFileHash(hashConn *dbconn.DBConn, tableFQN string) string {
-	parts := splitFQN(tableFQN)
-	if len(parts) != 2 {
-		return ""
-	}
-	schema, table := parts[0], parts[1]
-
+// getTableFileHash computes an MD5 hash of per-segment data-file mtime+size for
+// a heap table, using gp_toolkit.gpbackup_file_info(oid). gp_dist_random('gp_id')
+// runs the function locally on each segment; pg_relation_filepath on the segment
+// resolves the local path, so each segment hashes its own copy of the table.
+func getTableFileHash(hashConn *dbconn.DBConn, oid uint32, fqn string) string {
+	// oid is interpolated as an integer literal -- no string-escaping concerns.
 	query := fmt.Sprintf(`
 		SELECT COALESCE(md5(string_agg(
 			gp_segment_id::text || ',' || info, chr(10) ORDER BY gp_segment_id
 		)), '') AS filehash
 		FROM (
 			SELECT gp_segment_id,
-				gp_toolkit.gpbackup_file_info('%s', '%s') AS info
+				gp_toolkit.gpbackup_file_info(%d::oid) AS info
 			FROM gp_dist_random('gp_id')
 		) x
-		WHERE info <> ''`,
-		schema, table)
+		WHERE info <> ''`, oid)
 
 	var results []struct{ FileHash string }
 	err := hashConn.Select(&results, query)
 	if err != nil {
-		gplog.Warn("Could not get file hash for %s: %v", tableFQN, err)
+		gplog.Warn("Could not get file hash for %s: %v", fqn, err)
 		return ""
 	}
 	if len(results) == 0 || results[0].FileHash == "" {
 		return ""
 	}
 	return results[0].FileHash
-}
-
-// splitFQN splits "schema.table" into [schema, table], stripping quote chars.
-func splitFQN(fqn string) []string {
-	fqn = strings.ReplaceAll(fqn, "\"", "")
-	parts := strings.SplitN(fqn, ".", 2)
-	return parts
 }
 
 // GetAOContentHashes returns a per-table aoseg content hash for every AO/AOCS table.
@@ -373,8 +365,11 @@ func GetAOContentHashes(connectionPool *dbconn.DBConn) map[string]string {
 //   - AO row (pg_aoseg_*): segno + eof + tupcount.
 //   - AOCS column store (pg_aocsseg_*): layout differs by product / version.
 //     Cloudberry AOCS exposes vpinfo (vertical-partition info, a bytea containing
-//     per-column eofs); GP7+ exposes column_num + physical_segno + eof_uncompressed;
-//     pre-GP6 only has segno + tupcount.
+//     per-column eofs); GPDB 6+ exposes column_num + physical_segno +
+//     eof_uncompressed; pre-GP6 only has segno + tupcount. If a column is missing
+//     on a given version, the query fails and getAOSegContentHash returns "",
+//     and FilterTablesForIncremental falls back to modcount comparison for that
+//     table.
 func getAOSegContentHash(hashConn *dbconn.DBConn, aosegTableFQN string) string {
 	isColumnStore := strings.Contains(aosegTableFQN, "pg_aocsseg")
 
@@ -387,7 +382,7 @@ func getAOSegContentHash(hashConn *dbconn.DBConn, aosegTableFQN string) string {
 		case hashConn.Version.Before("6"):
 			cols = "segno::text || ',' || tupcount::text"
 		default:
-			// GP7+ AOCS
+			// GPDB 6+ AOCS
 			cols = "segno::text || ',' || column_num::text || ',' || physical_segno::text || ',' || tupcount::text || ',' || eof_uncompressed::text"
 		}
 	} else {

--- a/backup/validate.go
+++ b/backup/validate.go
@@ -156,6 +156,12 @@ func validateFlagCombinations(flags *pflag.FlagSet) {
 	if MustGetFlagBool(options.INCREMENTAL) && !MustGetFlagBool(options.LEAF_PARTITION_DATA) {
 		gplog.Fatal(errors.Errorf("--leaf-partition-data must be specified with --incremental"), "")
 	}
+	if MustGetFlagBool(options.HEAP_FILE_HASH) && !MustGetFlagBool(options.INCREMENTAL) && !MustGetFlagBool(options.LEAF_PARTITION_DATA) {
+		gplog.Fatal(errors.Errorf("--heap-file-hash requires --leaf-partition-data (for full backup baseline) or --incremental"), "")
+	}
+	if MustGetFlagBool(options.AO_FILE_HASH) && !MustGetFlagBool(options.INCREMENTAL) && !MustGetFlagBool(options.LEAF_PARTITION_DATA) {
+		gplog.Fatal(errors.Errorf("--ao-file-hash requires --leaf-partition-data (for full backup baseline) or --incremental"), "")
+	}
 	if MustGetFlagBool(options.NO_INHERITS) && !(FlagChanged(options.INCLUDE_RELATION) || FlagChanged(options.INCLUDE_RELATION_FILE)) {
 		gplog.Fatal(errors.Errorf("--no-inherits must be specified with either --include-table or --include-table-file"), "")
 	}

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -801,8 +801,8 @@ func backupIncrementalMetadata() {
 				gplog.Warn("CHECKPOINT failed (non-fatal, file hashes may be stale): %v", cpErr)
 			}
 
-			heapFQNs := getHeapTableFQNs(connectionPool)
-			heapFileHashes := getFileHashesForTables(hashConn, heapFQNs)
+			heapTables := getHeapTables(connectionPool)
+			heapFileHashes := getFileHashesForTables(hashConn, heapTables)
 			heapEntries := make(map[string]toc.HeapEntry)
 			for fqn, hash := range heapFileHashes {
 				if hash != "" {

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -760,8 +760,64 @@ func backupTableStatistics(statisticsFile *utils.FileWithByteCount, tables []Tab
 }
 
 func backupIncrementalMetadata() {
+	// Always collect AO metadata via modcount + DDL timestamp.
 	aoTableEntries := GetAOIncrementalMetadata(connectionPool)
 	globalTOC.IncrementalMetadata.AO = aoTableEntries
+
+	useHeapHash := MustGetFlagBool(options.HEAP_FILE_HASH)
+	useAOHash := MustGetFlagBool(options.AO_FILE_HASH)
+
+	if !useHeapHash && !useAOHash {
+		gplog.Info("Collected incremental metadata: %d AO tables", len(aoTableEntries))
+		return
+	}
+
+	aoContentHashCount := 0
+	if useAOHash {
+		gplog.Info("Collecting AO aoseg content hashes (--ao-file-hash)")
+		aoContentHashes := GetAOContentHashes(connectionPool)
+		aoContentHashCount = len(aoContentHashes)
+		for fqn, hash := range aoContentHashes {
+			if existing, ok := aoTableEntries[fqn]; ok {
+				existing.FileHashMD5 = hash
+				aoTableEntries[fqn] = existing
+			}
+		}
+		globalTOC.IncrementalMetadata.AO = aoTableEntries
+	}
+
+	heapHashCount := 0
+	if useHeapHash {
+		if !ensureFileStatFunction(connectionPool) {
+			gplog.Warn("File hash setup incomplete, skipping heap file hash collection")
+		} else {
+			hashConn := dbconn.NewDBConnFromEnvironment(connectionPool.DBName)
+			hashConn.MustConnect(1)
+			defer hashConn.Close()
+
+			// CHECKPOINT flushes dirty pages so pg_stat_file sees up-to-date mtime/size.
+			gplog.Verbose("Executing CHECKPOINT before heap file hash collection")
+			if _, cpErr := hashConn.Exec("CHECKPOINT;", 0); cpErr != nil {
+				gplog.Warn("CHECKPOINT failed (non-fatal, file hashes may be stale): %v", cpErr)
+			}
+
+			heapFQNs := getHeapTableFQNs(connectionPool)
+			heapFileHashes := getFileHashesForTables(hashConn, heapFQNs)
+			heapEntries := make(map[string]toc.HeapEntry)
+			for fqn, hash := range heapFileHashes {
+				if hash != "" {
+					heapEntries[fqn] = toc.HeapEntry{FileHashMD5: hash}
+				}
+			}
+			if len(heapEntries) > 0 {
+				globalTOC.IncrementalMetadata.Heap = heapEntries
+			}
+			heapHashCount = len(heapEntries)
+		}
+	}
+
+	gplog.Info("Collected incremental metadata: %d AO tables (%d with content hash), %d heap tables",
+		len(aoTableEntries), aoContentHashCount, heapHashCount)
 }
 
 func backupStorageServers(metadataFile *utils.FileWithByteCount) {

--- a/options/flag.go
+++ b/options/flag.go
@@ -54,6 +54,8 @@ const (
 	RESIZE_CLUSTER        = "resize-cluster"
 	NO_INHERITS           = "no-inherits"
 	REPORT_DIR            = "report-dir"
+	HEAP_FILE_HASH        = "heap-file-hash"
+	AO_FILE_HASH          = "ao-file-hash"
 )
 
 func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
@@ -89,6 +91,8 @@ func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.Bool(WITH_STATS, false, "Back up query plan statistics")
 	flagSet.Bool(WITHOUT_GLOBALS, false, "Skip backup of global metadata")
 	flagSet.Bool(NO_INHERITS, false, "For a filtered backup, don't back up all tables that inherit included tables")
+	flagSet.Bool(HEAP_FILE_HASH, false, "Use file timestamp hash (CHECKPOINT + pg_stat_file) to detect heap table changes for incremental backup")
+	flagSet.Bool(AO_FILE_HASH, false, "Use aoseg content hash (eof+tupcount) for per-partition AO table change detection; avoids GP5 modcount cross-partition propagation")
 }
 
 func SetRestoreFlagDefaults(flagSet *pflag.FlagSet) {

--- a/toc/toc.go
+++ b/toc/toc.go
@@ -64,7 +64,7 @@ type AOEntry struct {
 }
 
 type HeapEntry struct {
-	FileHashMD5 string `yaml:"fileHashMD5"`
+	FileHashMD5 string `yaml:"fileHashMD5,omitempty"`
 }
 
 type UniqueID struct {

--- a/toc/toc.go
+++ b/toc/toc.go
@@ -53,12 +53,18 @@ type SegmentDataEntry struct {
 }
 
 type IncrementalEntries struct {
-	AO map[string]AOEntry
+	AO   map[string]AOEntry
+	Heap map[string]HeapEntry `yaml:"heap,omitempty"`
 }
 
 type AOEntry struct {
 	Modcount         int64
 	LastDDLTimestamp string
+	FileHashMD5      string `yaml:"fileHashMD5,omitempty"`
+}
+
+type HeapEntry struct {
+	FileHashMD5 string `yaml:"fileHashMD5"`
 }
 
 type UniqueID struct {


### PR DESCRIPTION
## Summary

Adds two independent, opt-in flags to `gpbackup` that let `--incremental` detect table-level changes by hashing physical-storage state rather than relying solely on AO `modcount`:

- **`--heap-file-hash`** — hashes each heap table's per-segment data-file mtime+size (via `pg_stat_file()` after a `CHECKPOINT`), so unchanged heap tables can be skipped from incremental for the first time. Default behavior — *always include heap* — is preserved when the flag is absent.
- **`--ao-file-hash`** — hashes the AO/AOCS table's `pg_aoseg` content rows (`segno + eof + tupcount`, deliberately excluding `modcount`). This gives partition-leaf change detection in GP5 (where parent `modcount` propagates across sibling partitions) and catches some `modcount`-doesn't-match-data edge cases. AOCS uses a Cloudberry-aware column set (`vpinfo` when `!IsGPDB()`, otherwise the GP6+ schema).

Both flags require `--leaf-partition-data` or `--incremental` (validated in `validate.go`).

## Motivation

Two long-standing gaps in incremental backup:

1. **Heap tables had no change detection at all** — every incremental backup re-copied every heap table, regardless of whether the data file changed. For deployments with a few large mostly-static heap tables, this dominates incremental wall-time and storage.
2. **AO `modcount` is sometimes wrong** — on GP5-style storage, the parent partition's `modcount` is the sum across children, so a single child write makes every sibling appear changed. This PR ports the algorithm originally developed in `cloudberry-fe/gpbackup-enhanced` into Apache Cloudberry-backup with conventions cleaned up and lint compliance.

## Approach

- **Catalog metadata for change detection lives in the TOC** — `IncrementalEntries.AO` already exists; this PR adds an optional `Heap` map and an optional `FileHashMD5` field to `AOEntry`, both `yaml:",omitempty"`. TOCs written without the new flags are bytewise identical to today's. Older `gprestore` reads new TOCs without issue (extra fields ignored).
- **Hash collection runs on a dedicated `dbconn`** so a per-table query failure doesn't abort the backup transaction. The heap path also issues a `CHECKPOINT` first to flush dirty pages, so `pg_stat_file` mtime/size reflect data state and not just buffer state.
- **The heap path uses `pg_relation_filepath(oid)`** rather than constructing the on-disk path manually — this avoids the very-easy-to-get-wrong `pg_tblspc/<oid>/PG_<major>_<catver>/...` path inside the plpgsql helper and is robust across PG/Cloudberry versions and tablespaces.
- **OID is passed to the plpgsql helper** (not schema/table strings), so SQL escaping isn't a concern and identifiers with embedded quotes just work.
- **`FilterTablesForIncremental` branches independently on each flag**. When neither flag is set, control flow is logically identical to the previous version (AO compared by `modcount + DDL timestamp`; heap unconditionally included).

## Files changed

| File | Change |
|---|---|
| `toc/toc.go` | Add `HeapEntry`; add `IncrementalEntries.Heap` and `AOEntry.FileHashMD5` (both `omitempty`). |
| `options/flag.go` | Add `HEAP_FILE_HASH`, `AO_FILE_HASH` constants and pflag registrations. |
| `backup/queries_incremental.go` | New: `ensureFileStatFunction`, `getHeapTables`, `getTableFileHash`, `getFileHashesForTables`, `GetAOContentHashes`, `getAOSegContentHash`. plpgsql helper `gp_toolkit.gpbackup_file_info(p_oid oid)` uses `pg_relation_filepath(oid) + pg_stat_file()`. |
| `backup/wrappers.go` | `backupIncrementalMetadata` now optionally `CHECKPOINT`s and collects heap + AO content hashes. |
| `backup/incremental.go` | `FilterTablesForIncremental` rewrite with independent AO/heap branches. |
| `backup/validate.go` | Reject `--heap-file-hash` / `--ao-file-hash` without `--leaf-partition-data` or `--incremental`. |
| `backup/incremental_test.go` | Move `FilterTablesForIncremental` call into `JustBeforeEach` so package-level `cmdFlags` is initialized first. |

## Backward compatibility

Fully compatible.

- Without the new flags: behavior matches the prior release exactly. The default code path is reduced to the same comparison logic as the old `FilterTablesForIncremental`.
- TOC schema additions are all `yaml:",omitempty"`. Old TOCs deserialize into the new structs; new TOCs without these flags serialize bytewise-identically to the old format.
- `gp_toolkit.gpbackup_file_info` is only created when `--heap-file-hash` is used; if a previous gpbackup version installed an older `(text, text)` signature, the setup path drops it first (`DROP FUNCTION IF EXISTS ... (text, text)`).

## How tested

- `make build`: 5 binaries built cleanly.
- `make lint`: no new findings attributable to this change (pre-existing errcheck/unparam issues in unrelated files are unchanged).
- `make unit`: all 13 Ginkgo suites pass.
- `make end_to_end`: 162 / 196 active specs PASS / 0 regressions traceable to this change. The 34 failures are all environmental (`gpbackman` binary path, leftover `test_queue`/`test_tablespace` between specs, and one test that creates tables without `USING heap` on a cluster whose default access method is `ao_row`).
- **Targeted live e2e on Cloudberry 2.5.0** — mixed schema with heap, AO row, AOCS, and partitioned AO; full + mutate + incremental cycle with both flags. Verified: changed tables included, unchanged tables skipped, partition-leaf granularity correct (one leaf included, sibling skipped), restore round-trip row counts match across all tables.
- **Targeted live e2e on Synxdb 4.5.0-rc.3 with custom tablespace** — additionally verified that heap tables in a non-default tablespace are correctly detected as changed/unchanged. This is the empirical proof that `pg_relation_filepath()` handles the tablespace path correctly — without it, custom-tablespace heap would silently break in incremental detection.

The e2e scripts used for verification are reproducible; happy to commit them into `end_to_end/` as a follow-up if reviewers want a regression test for the feature.

## Contributor's checklist

- [x] Commits are logical units (one feat, one follow-up fix from code review).
- [x] CI is expected to pass: `rat-check`, `build_and_unit_test`, smoke/unit/integration/end_to_end/s3_plugin_e2e/regression/scale.
- [x] Code follows existing style; `gofmt` / `goimports` clean.
- [ ] Squash if reviewers prefer a single commit — happy to do either.
- [ ] `Signed-off-by` not currently included; will amend if reviewers want DCO.