### PR TITLE
CI: pin Cloudberry branch to `REL_2_STABLE`

### DIFF
--- a/.github/workflows/cloudberry-backup-ci.yml
+++ b/.github/workflows/cloudberry-backup-ci.yml
@@ -53,7 +53,9 @@ permissions:
 
 env:
   CLOUDBERRY_REPO: apache/cloudberry
-  CLOUDBERRY_REF: main
+  # Currently targeting REL_2_STABLE (2.x) branch only.
+  # TODO: Switch back to "main" once Cloudberry 3.x / main branch stabilizes with PG16 support.
+  CLOUDBERRY_REF: REL_2_STABLE
   CLOUDBERRY_DIR: cloudberry
   CLOUDBERRY_BACKUP_DIR: cloudberry-backup
 


### PR DESCRIPTION
Switch the CI Cloudberry checkout from `main` to `REL_2_STABLE branch`.

Cloudberry main has upgraded to the PG16 kernel, whose tightened role grant permission checks (GRANT ... GRANTED BY now requires ADMIN OPTION) break multiple backup integration tests.  `REL_2_STABLE` still runs PG14 and passes the full test suite without these failures.

Add a TODO to revert to main once Cloudberry 3.x stabilizes with PG16.

See: https://github.com/apache/cloudberry-backup/issues/103

<!--Thank you for contributing! -->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that CICD workflow is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-backup/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.
