### PR TITLE
Update golangci-lint and resolve lint findings.

### DIFF
--- a/.github/workflows/build_and_unit_test.yml
+++ b/.github/workflows/build_and_unit_test.yml
@@ -33,6 +33,12 @@ jobs:
         cd ${GOPATH}/src/github.com/apache/cloudberry-backup
         make depend
 
+    - name: Run linters
+      uses: golangci/golangci-lint-action@v9
+      with:
+        version: v2.12.2
+        working-directory: go/src/github.com/apache/cloudberry-backup
+
     - name: Build
       run: |
         cd ${GOPATH}/src/github.com/apache/cloudberry-backup

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,12 @@ linters:
   enable:
     - errcheck
     - govet
+    - ineffassign
+    - misspell
+    - nakedret
     - revive
+    - staticcheck
+    - unconvert
     - unparam
     - unused
   settings:
@@ -31,6 +36,12 @@ linters:
         - shadow
     revive:
       confidence: 0.1
+    misspell:
+      locale: US
+    staticcheck:
+      checks:
+        - "SA*"
+        - "-SA1019"
   exclusions:
     generated: lax
     rules:
@@ -67,3 +78,4 @@ linters:
 
 run:
   timeout: 5m
+  modules-download-mode: readonly

--- a/Makefile
+++ b/Makefile
@@ -59,15 +59,10 @@ $(GOSQLITE) :
 format : $(GOIMPORTS)
 		@goimports -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
-LINTER_VERSION=2.10.1
-$(GOLANG_LINTER) :
-		mkdir -p $(GOPATH)/bin
-		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh | sh -s -- -b $(GOPATH)/bin v${LINTER_VERSION}
+.PHONY : coverage integration end_to_end lint
 
-.PHONY : coverage integration end_to_end
-
-lint : $(GOLANG_LINTER)
-		golangci-lint run
+lint :
+		$(GOLANG_LINTER) run
 
 unit : $(GINKGO)
 	TEST_DB_TYPE=CBDB TEST_DB_VERSION=2.999.0 ginkgo $(GINKGO_FLAGS) $(SUBDIRS_HAS_UNIT) 2>&1

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ EXPORTER_VERSION_STR=-X github.com/prometheus/common/version.Version=$(GIT_VERSI
 # note that /testutils is not a production directory, but has unit tests to validate testing tools
 SUBDIRS_HAS_UNIT=backup/ filepath/ history/ helper/ options/ report/ restore/ toc/ utils/ testutils/ plugins/s3plugin/ gpbackman/cmd/ gpbackman/gpbckpconfig/ gpbackman/textmsg/ exporter/
 SUBDIRS_ALL=$(SUBDIRS_HAS_UNIT) integration/ end_to_end/
+GOLANGCI_LINT_VERSION=v2.12.2
 GOLANG_LINTER=$(GOPATH)/bin/golangci-lint
 GINKGO=$(GOPATH)/bin/ginkgo
 GOIMPORTS=$(GOPATH)/bin/goimports
@@ -56,12 +57,15 @@ $(GOIMPORTS) :
 $(GOSQLITE) :
 	go install github.com/mattn/go-sqlite3
 
+$(GOLANG_LINTER) :
+	GOBIN=$(GOPATH)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
 format : $(GOIMPORTS)
 		@goimports -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 .PHONY : coverage integration end_to_end lint
 
-lint :
+lint : $(GOLANG_LINTER)
 		$(GOLANG_LINTER) run
 
 unit : $(GINKGO)

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ popd
 
 **NOTE**: The integration and end_to_end tests require a running Cloudberry instance.
 
-* To run all tests except end-to-end (linters, unit, and integration), use `make test`.
+* To build and run unit and integration tests, use `make test`.
 * To run only unit tests, use `make unit`.
 * To run only integration tests (requires a running Cloudberry instance), use `make integration`.
 * To run end to end tests (requires a running Cloudberry instance), use `make end_to_end`.
@@ -183,8 +183,9 @@ We provide the following targets to help developers ensure their code fits
 Go standard formatting guidelines:
 
 * To run a linting tool that checks for basic coding errors, use: `make lint`.
-This target runs [gometalinter](https://github.com/alecthomas/gometalinter).
-Note: The lint target will fail if code is not formatted properly.
+This target runs [golangci-lint](https://golangci-lint.run/) installed in
+`$(GOPATH)/bin`. CI installs its pinned version through the official GitHub
+Action.
 
 * To automatically format your code and add/remove imports, use `make format`.
 This target runs

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -172,7 +172,7 @@ func DoBackup() {
 			gplog.FatalOnError(err)
 		} else {
 			err = history.StoreBackupHistory(historyDB, &backupReport.BackupConfig)
-			historyDB.Close()
+			_ = historyDB.Close()
 			gplog.FatalOnError(err)
 		}
 	}
@@ -245,7 +245,6 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 	}
 	gplog.Info("Writing pre-data metadata")
 
-	var protocols []ExternalProtocol
 	var functions []Function
 	var funcInfoMap map[uint32]FunctionInfo
 	objects := make([]Sortable, 0)
@@ -259,7 +258,7 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 	addToMetadataMap(relationMetadata, metadataMap)
 
 	if !tableOnly {
-		protocols = retrieveProtocols(&objects, metadataMap)
+		retrieveProtocols(&objects, metadataMap)
 		backupSchemas(metadataFile, createAlteredPartitionSchemaSet(tables))
 		backupExtensions(metadataFile)
 		backupCollations(metadataFile)
@@ -283,7 +282,7 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 	sequences := retrieveAndBackupSequences(metadataFile, relationMetadata)
 	domainConstraints, nonDomainConstraints, conMetadata := retrieveConstraints(&objects, metadataMap)
 
-	viewsDependingOnConstraints := backupDependentObjects(metadataFile, tables, protocols, metadataMap, domainConstraints, objects, sequences, funcInfoMap, tableOnly)
+	viewsDependingOnConstraints := backupDependentObjects(metadataFile, tables, metadataMap, domainConstraints, objects, sequences, funcInfoMap)
 
 	backupConversions(metadataFile)
 
@@ -523,7 +522,7 @@ func DoCleanup(backupFailed bool) {
 			gplog.Error("Unable to update history database. Error: %v", err)
 		} else {
 			_, err := historyDB.Exec(fmt.Sprintf("UPDATE backups SET status='%s', end_time='%s' WHERE timestamp='%s'", statusString, backupReport.BackupConfig.EndTime, globalFPInfo.Timestamp))
-			historyDB.Close()
+			_ = historyDB.Close()
 			if err != nil {
 				gplog.Error("Unable to update history database. Error: %v", err)
 			} else {
@@ -683,7 +682,7 @@ func getTableLocks(table Table) []TableLocks {
 	return locksResults
 }
 
-func logTableLocks(table Table, whichConn int) {
+func logTableLocks(table Table) {
 	locks := getTableLocks(table)
 	jsonData, _ := json.Marshal(&locks)
 	gplog.Warn("Locks held on table %s: %s", table.FQN(), jsonData)

--- a/backup/data.go
+++ b/backup/data.go
@@ -234,7 +234,7 @@ func BackupDataForAllTables(tables []Table) []map[uint32]int64 {
 						fmt.Printf("\n")
 					}
 					gplog.Warn("Worker %d could not acquire AccessShareLock for table %s.", whichConn, table.FQN())
-					logTableLocks(table, whichConn)
+					logTableLocks(table)
 					// rollback transaction and defer table
 					err = connectionPool.Rollback(whichConn)
 					if err != nil {

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -239,7 +239,7 @@ func assignCohorts(slice []Sortable, dependencies DependencyMap, isDependentOn m
 	// to the toc.
 	for id := range tierMap {
 		cohort := objectToCohortMap[id]
-		tierMap[id][1] = uint32(cohort)
+		tierMap[id][1] = cohort
 	}
 	return
 }

--- a/backup/dependencies_test.go
+++ b/backup/dependencies_test.go
@@ -86,7 +86,7 @@ var _ = Describe("backup/dependencies tests", func() {
 				testhelper.ExpectRegexp(logfile, "\tpublic.relation2 {ClassID:1259 Oid:2}")
 			}()
 			defer testhelper.ShouldPanicWithMessage("Dependency resolution failed; see log file gbytes.Buffer for details. This is a bug, please report.")
-			sortable, _ = backup.TopologicalSort(sortable, depMap)
+			_, _ = backup.TopologicalSort(sortable, depMap)
 		})
 		It("aborts if dependencies are not met", func() {
 			depMap[backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: 1}] = map[backup.UniqueID]bool{{ClassID: backup.PG_CLASS_OID, Oid: 2}: true}
@@ -94,7 +94,7 @@ var _ = Describe("backup/dependencies tests", func() {
 			sortable := []backup.Sortable{relation1, relation2}
 
 			defer testhelper.ShouldPanicWithMessage("Dependency resolution failed; see log file gbytes.Buffer for details. This is a bug, please report.")
-			sortable, _ = backup.TopologicalSort(sortable, depMap)
+			_, _ = backup.TopologicalSort(sortable, depMap)
 		})
 	})
 	Describe("PrintDependentObjectStatements", func() {

--- a/backup/incremental.go
+++ b/backup/incremental.go
@@ -89,7 +89,9 @@ func GetLatestMatchingBackupConfig(historyDBPath string, currentBackupConfig *hi
 		gplog.Error("%s", err.Error())
 		return nil
 	}
-	defer timestampRows.Close()
+	defer func() {
+		_ = timestampRows.Close()
+	}()
 
 	timestamps := make([]string, 0)
 	for timestampRows.Next() {

--- a/backup/predata_externals.go
+++ b/backup/predata_externals.go
@@ -292,8 +292,6 @@ func PrintExternalTableStatements(metadataFile *utils.FileWithByteCount, tableNa
 	if extTableDef.Type == READABLE || (extTableDef.Type == WRITABLE_WEB && extTableDef.Protocol == S3) {
 		if extTableDef.ExecLocation == "COORDINATOR_ONLY" {
 			metadataFile.MustPrintf(" ON COORDINATOR")
-		} else if extTableDef.ExecLocation == "COORDINATOR_ONLY" {
-			metadataFile.MustPrintf(" ON COORDINATOR")
 		}
 	}
 	if extTableDef.Type == READABLE_WEB || extTableDef.Type == WRITABLE_WEB {

--- a/backup/predata_externals_test.go
+++ b/backup/predata_externals_test.go
@@ -320,7 +320,7 @@ SEGMENT REJECT LIMIT 2 ROWS`)
 
 				Expect(resultStatement).To(Equal(`FORMAT 'TEXT'`))
 			})
-			It("generates a FORMAT statment with some options provided", func() {
+			It("generates a FORMAT statement with some options provided", func() {
 				extTableDef.FormatType = "t"
 				extTableDef.FormatOpts = `delimiter '\t' null '\N' escape '\'`
 

--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -291,7 +291,7 @@ func PrintCreateExtensionStatements(metadataFile *utils.FileWithByteCount, objTo
 	for _, extensionDef := range extensionDefs {
 		start := metadataFile.ByteCount
 		if (connectionPool.Version.IsGPDB() && connectionPool.Version.AtLeast("7")) || connectionPool.Version.IsCBDB() {
-			// changes to gp_toolkit in gpdb7 require explicilty creating the schema before the extension
+			// changes to gp_toolkit in gpdb7 require explicitly creating the schema before the extension
 			metadataFile.MustPrintf(
 				"\n\nCREATE SCHEMA IF NOT EXISTS %[1]s;\nSET search_path=%[1]s,pg_catalog;\nCREATE EXTENSION IF NOT EXISTS %[2]s WITH SCHEMA %[1]s;\nSET search_path=pg_catalog;\n",
 				extensionDef.Schema, extensionDef.Name)

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -463,8 +463,8 @@ func PrintCreatePostdataViewStatements(metadataFile *utils.FileWithByteCount, ob
 	for _, view := range views {
 		start := metadataFile.ByteCount
 		metadataFile.MustPrintf("\n\nCREATE OR REPLACE VIEW %s%s AS %s\n", view.FQN(), view.Options, view.Definition.String)
-		section, entry := view.GetMetadataEntry()
-		section = "postdata"
+		_, entry := view.GetMetadataEntry()
+		section := "postdata"
 		tier := globalTierMap[view.GetUniqueID()]
 		objToc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount, tier)
 	}

--- a/backup/predata_shared.go
+++ b/backup/predata_shared.go
@@ -38,7 +38,7 @@ func PrintConstraintStatements(metadataFile *utils.FileWithByteCount, objToc *to
 	for _, constraint := range constraints {
 		start := metadataFile.ByteCount
 
-		// ConIsLocal should always return true from GetConstraints because we filter out constraints that are inherited using the INHERITS clause, or inherited from a parent partition table. This field only accurately reflects constraints in GPDB6+ because check constraints on parent tables must propogate to children. For GPDB versions 5 or lower, this field will default to false.
+		// ConIsLocal should always return true from GetConstraints because we filter out constraints that are inherited using the INHERITS clause, or inherited from a parent partition table. This field only accurately reflects constraints in GPDB6+ because check constraints on parent tables must propagate to children. For GPDB versions 5 or lower, this field will default to false.
 		objStr := "TABLE ONLY"
 		if constraint.IsPartitionParent || (constraint.ConType == "c" && constraint.ConIsLocal) {
 			objStr = toc.OBJ_TABLE

--- a/backup/queries_acl.go
+++ b/backup/queries_acl.go
@@ -324,7 +324,7 @@ func GetDefaultPrivileges(connectionPool *dbconn.DBConn) []DefaultPrivileges {
 	// Cannot use unnest() in CASE statements anymore in GPDB 7+ so convert
 	// it to a LEFT JOIN LATERAL. We do not use LEFT JOIN LATERAL for GPDB 6
 	// because the CASE unnest() logic is more performant.
-	aclCols := "''"
+	var aclCols string
 	aclLateralJoin := ""
 	if (connectionPool.Version.IsGPDB() && connectionPool.Version.AtLeast("7")) || connectionPool.Version.IsCBDB() {
 		aclLateralJoin =

--- a/backup/queries_shared.go
+++ b/backup/queries_shared.go
@@ -114,7 +114,7 @@ func GetConstraints(connectionPool *dbconn.DBConn, includeTables ...Relation) []
 	// filter out constraints that are inherited using the INHERITS clause, or
 	// inherited from a parent partition table. This field only accurately
 	// reflects constraints in GPDB6+ because check constraints on parent
-	// tables must propogate to children. For GPDB versions 5 or lower, this
+	// tables must propagate to children. For GPDB versions 5 or lower, this
 	// field will default to false.
 	conIsLocal := ""
 	if (connectionPool.Version.IsGPDB() && connectionPool.Version.AtLeast("6")) || connectionPool.Version.IsCBDB() {

--- a/backup/queries_table_defs.go
+++ b/backup/queries_table_defs.go
@@ -375,7 +375,7 @@ func GetColumnDefinitions(connectionPool *dbconn.DBConn) map[uint32][]ColumnDefi
 		AND a.attisdropped = 'f'
 	ORDER BY a.attrelid, a.attnum`, relationAndSchemaFilterClause())
 
-	query := ``
+	var query string
 	if connectionPool.Version.IsGPDB() && connectionPool.Version.Before("6") {
 		query = before6Query
 	} else if connectionPool.Version.IsGPDB() && connectionPool.Version.Is("6") {
@@ -736,7 +736,7 @@ func GetTableInheritance(connectionPool *dbconn.DBConn, tables []Relation) map[u
 	return resultMap
 }
 
-// Used to contruct root tables for GPDB 7+, because the root partition must be
+// Used to construct root tables for GPDB 7+, because the root partition must be
 // constructed by itself first.
 func GetPartitionKeyDefs(connectionPool *dbconn.DBConn) map[uint32]string {
 	if connectionPool.Version.IsGPDB() && connectionPool.Version.Before("7") {

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -85,7 +85,7 @@ func initializeConnectionPool(timestamp string) {
 }
 
 func SetSessionGUCs(connNum int) {
-	// These GUCs ensure the dumps portability accross systems
+	// These GUCs ensure the dumps portability across systems
 	connectionPool.MustExec("SET search_path TO pg_catalog", connNum)
 	connectionPool.MustExec("SET statement_timeout = 0", connNum)
 	connectionPool.MustExec("SET DATESTYLE = ISO", connNum)
@@ -616,8 +616,8 @@ func addToMetadataMap(newMetadata MetadataMap, metadataMap MetadataMap) {
 
 // This function is fairly unwieldy, but there's not really a good way to break it down
 func backupDependentObjects(metadataFile *utils.FileWithByteCount, tables []Table,
-	protocols []ExternalProtocol, filteredMetadata MetadataMap, domainConstraints []Constraint,
-	sortables []Sortable, sequences []Sequence, funcInfoMap map[uint32]FunctionInfo, tableOnly bool) []View {
+	filteredMetadata MetadataMap, domainConstraints []Constraint,
+	sortables []Sortable, sequences []Sequence, funcInfoMap map[uint32]FunctionInfo) []View {
 	var sortedSlice []Sortable
 	gplog.Verbose("Writing CREATE statements for dependent objects to metadata file")
 

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -927,13 +927,13 @@ var _ = Describe("backup and restore end to end tests", func() {
 			helperLogs, _ := path.Glob(path.Join(homeDir, "gpAdminLogs/gprestore_*"))
 			cmdStr := fmt.Sprintf("tail -n 40 %s | grep \"Creating skip file\" || true", helperLogs[len(helperLogs)-1])
 
-			attemts := 1000
+			attempts := 1000
 			err = errors.New("Timeout to discover skip file")
-			for attemts > 0 {
+			for attempts > 0 {
 				output := mustRunCommand(exec.Command("bash", "-c", cmdStr))
 				if strings.TrimSpace(string(output)) == "" {
 					time.Sleep(5 * time.Millisecond)
-					attemts--
+					attempts--
 				} else {
 					err = nil
 					break
@@ -2511,7 +2511,7 @@ LANGUAGE plpgsql NO SQL;`)
 			Expect(err).To(HaveOccurred())
 			Expect(string(output)).To(MatchRegexp("Segment count for backup with timestamp [0-9]+ is unknown, cannot restore using --resize-cluster flag"))
 		})
-		It("Will not restore to a different-size cluster without the approprate flag", func() {
+		It("Will not restore to a different-size cluster without the appropriate flag", func() {
 			command := exec.Command("tar", "-xzf", "resources/5-segment-db.tar.gz", "-C", backupDir)
 			mustRunCommand(command)
 

--- a/filepath/filepath.go
+++ b/filepath/filepath.go
@@ -273,7 +273,7 @@ func GetTimestampFromBackupDirectory(backupDir string) (string, error) {
 		return "", fmt.Errorf("Multiple timestamp directories found under %s, please specify a timestamp using the --timestamp flag", backupDir)
 	}
 
-	timestamp := path.Base(string(timestampDirs[0]))
+	timestamp := path.Base(timestampDirs[0])
 	return timestamp, nil
 }
 

--- a/gpbackman/cmd/wrappers.go
+++ b/gpbackman/cmd/wrappers.go
@@ -97,7 +97,7 @@ func setLogLevelFile(level string) error {
 // COORDINATOR_DATA_DIRECTORY environment variable exported by the standard
 // Cloudberry environment scripts. As a final fallback, return the bare
 // filename so it is resolved against the current working directory,
-// preserving the original behaviour for the default invocation.
+// preserving the original behavior for the default invocation.
 func getHistoryDBPath(historyDBPath string, autoLoad bool) string {
 	if historyDBPath != "" {
 		return historyDBPath
@@ -252,7 +252,9 @@ func getBackupMasterDirClusterInfo(dbName string) string {
 		gplog.Error("%s", textmsg.ErrorTextUnableConnectLocalCluster(err))
 		return ""
 	}
-	defer db.Close()
+	defer func() {
+		_ = db.Close()
+	}()
 	sqlQuery := "SELECT datadir FROM gp_segment_configuration WHERE content = -1 AND role = 'p';"
 	queryResult, err := gpbckpconfig.ExecuteQueryLocalClusterConn[string](db, sqlQuery)
 	if err != nil {
@@ -270,7 +272,9 @@ func getSegmentConfigurationClusterInfo(dbName string) ([]gpbckpconfig.SegmentCo
 		gplog.Error("%s", textmsg.ErrorTextUnableConnectLocalCluster(err))
 		return queryResult, err
 	}
-	defer db.Close()
+	defer func() {
+		_ = db.Close()
+	}()
 	sqlQuery := "SELECT content as contentid, hostname, datadir FROM gp_segment_configuration WHERE role = 'p' and content != -1 ORDER BY content;"
 	queryResult, err = gpbckpconfig.ExecuteQueryLocalClusterConn[[]gpbckpconfig.SegmentConfig](db, sqlQuery)
 	if err != nil {

--- a/gpbackman/gpbckpconfig/utils_db.go
+++ b/gpbackman/gpbckpconfig/utils_db.go
@@ -216,7 +216,9 @@ func execQueryFunc(query string, historyDB *sql.DB, args ...any) ([]string, erro
 	if err != nil {
 		return nil, err
 	}
-	defer sqlRow.Close()
+	defer func() {
+		_ = sqlRow.Close()
+	}()
 	var resultList []string
 	for sqlRow.Next() {
 		var b string

--- a/helper/backup_helper.go
+++ b/helper/backup_helper.go
@@ -86,7 +86,7 @@ func doBackupAgent() error {
 
 		_ = readHandle.Close()
 		logInfo(fmt.Sprintf("Oid %d: Deleting pipe: %s\n", oid, currentPipe))
-		deletePipe(currentPipe)
+		_ = deletePipe(currentPipe)
 	}
 
 	_ = pipeWriter.Close()
@@ -141,19 +141,19 @@ func getBackupPipeWriter() (pipe BackupPipeWriterCloser, writeCmd *exec.Cmd, err
 
 	if *compressionLevel == 0 {
 		pipe = NewCommonBackupPipeWriterCloser(writeHandle)
-		return
+		return pipe, writeCmd, nil
 	}
 
 	if *compressionType == "gzip" {
 		pipe, err = NewGZipBackupPipeWriterCloser(writeHandle, *compressionLevel)
-		return
+		return pipe, writeCmd, err
 	}
 	if *compressionType == "zstd" {
 		pipe, err = NewZSTDBackupPipeWriterCloser(writeHandle, *compressionLevel)
-		return
+		return pipe, writeCmd, err
 	}
 
-	writeHandle.Close()
+	_ = writeHandle.Close()
 	// error logging handled by calling functions
 	return nil, nil, fmt.Errorf("unknown compression type '%s' (compression level %d)", *compressionType, *compressionLevel)
 }

--- a/helper/backup_helper_pipes.go
+++ b/helper/backup_helper_pipes.go
@@ -56,7 +56,7 @@ func NewGZipBackupPipeWriterCloser(writeHandle io.WriteCloser, compressLevel int
 	gzPipe.cPipe = NewCommonBackupPipeWriterCloser(writeHandle)
 	gzPipe.gzipWriter, err = gzip.NewWriterLevel(gzPipe.cPipe.bufIoWriter, compressLevel)
 	if err != nil {
-		gzPipe.cPipe.Close()
+		_ = gzPipe.cPipe.Close()
 	}
 	return
 }
@@ -80,7 +80,7 @@ func NewZSTDBackupPipeWriterCloser(writeHandle io.WriteCloser, compressLevel int
 	zstdPipe.cPipe = NewCommonBackupPipeWriterCloser(writeHandle)
 	zstdPipe.zstdEncoder, err = zstd.NewWriter(zstdPipe.cPipe.bufIoWriter, zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(compressLevel)))
 	if err != nil {
-		zstdPipe.cPipe.Close()
+		_ = zstdPipe.cPipe.Close()
 	}
 	return
 }

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -251,7 +251,7 @@ func getOidListFromFile(oidFileName string) ([]int, error) {
 
 func flushAndCloseRestoreWriter(pipeName string, oid int) error {
 	if writer != nil {
-		writer.Write([]byte{}) // simulate writer connected in case of error
+		_, _ = writer.Write([]byte{}) // simulate writer connected in case of error
 		err := writer.Flush()
 		if err != nil {
 			logError("Oid %d: Failed to flush pipe %s", oid, pipeName)
@@ -318,9 +318,9 @@ func DoCleanup() {
 	logVerbose("Cleanup complete")
 }
 
-func logInfo(s string, v ...interface{}) {
+func logInfo(s string) {
 	s = fmt.Sprintf("Segment %d: %s", *content, s)
-	gplog.Info(s, v...)
+	gplog.Info("%s", s)
 }
 
 func logWarn(s string, v ...interface{}) {

--- a/helper/restore_helper.go
+++ b/helper/restore_helper.go
@@ -26,8 +26,8 @@ type ReaderType string
 
 const (
 	SEEKABLE    ReaderType = "seekable" // reader which supports seek
-	NONSEEKABLE            = "discard"  // reader which is not seekable
-	SUBSET                 = "subset"   // reader which operates on pre filtered data
+	NONSEEKABLE ReaderType = "discard"  // reader which is not seekable
+	SUBSET      ReaderType = "subset"   // reader which operates on pre filtered data
 )
 
 var (
@@ -214,7 +214,7 @@ func doRestoreAgent() error {
 				// Close file before it gets overwritten. Free up these
 				// resources when the reader is not needed anymore.
 				if reader, ok := readers[contentToRestore]; ok {
-					reader.fileHandle.Close()
+					_ = reader.fileHandle.Close()
 				}
 				// We pre-create readers above for the sake of not re-opening SDF readers.  For MDF we can't
 				// re-use them but still having them in a map simplifies overall code flow.  We repeatedly assign
@@ -242,7 +242,6 @@ func doRestoreAgent() error {
 					// invocation from gprestore (e.g. create a --db-version flag option).
 					if *onErrorContinue && utils.FileExists(fmt.Sprintf("%s_skip_%d", *pipeFile, tableOid)) {
 						logWarn(fmt.Sprintf("Oid %d, Batch %d: Skip file discovered, skipping this relation.", tableOid, batchNum))
-						err = nil
 						goto LoopEnd
 					} else {
 						// keep trying to open the pipe
@@ -260,7 +259,7 @@ func doRestoreAgent() error {
 				// the writer for the pipe. To avoid having to write complex buffer
 				// logic for when os.write() returns EAGAIN due to full buffer, set
 				// the file descriptor to block on IO.
-				unix.SetNonblock(int(writeHandle.Fd()), false)
+				_ = unix.SetNonblock(int(writeHandle.Fd()), false)
 				logVerbose(fmt.Sprintf("Oid %d, Batch %d: Reader connected to pipe %s", tableOid, batchNum, path.Base(currentPipe)))
 				break
 			}
@@ -299,11 +298,6 @@ func doRestoreAgent() error {
 			// copied before it errored out
 			if *singleDataFile {
 				lastByte[contentToRestore] += uint64(bytesRead)
-			}
-			if errBuf.Len() > 0 {
-				err = errors.Wrap(err, strings.Trim(errBuf.String(), "\x00"))
-			} else {
-				err = errors.Wrap(err, "Error copying data")
 			}
 			goto LoopEnd
 		}
@@ -368,7 +362,7 @@ func getRestoreDataReader(fileToRead string, objToc *toc.SegmentTOC, oidList []i
 	var gzipReader *gzip.Reader
 	var zstdReader *zstd.Decoder
 	var isSubset bool
-	var err error = nil
+	var err error
 	restoreReader := new(RestoreReader)
 
 	if *pluginConfigFile != "" {
@@ -458,15 +452,15 @@ func startRestorePluginCommand(fileToRead string, objToc *toc.SegmentTOC, oidLis
 	if objToc != nil && pluginConfig.CanRestoreSubset() && *isFiltered && !strings.HasSuffix(fileToRead, ".gz") && !strings.HasSuffix(fileToRead, ".zst") {
 		offsetsFile, _ := os.CreateTemp("/tmp", "gprestore_offsets_")
 		defer func() {
-			offsetsFile.Close()
+			_ = offsetsFile.Close()
 		}()
 		w := bufio.NewWriter(offsetsFile)
-		w.WriteString(fmt.Sprintf("%v", len(oidList)))
+		_, _ = w.WriteString(fmt.Sprintf("%v", len(oidList)))
 
 		for _, oid := range oidList {
-			w.WriteString(fmt.Sprintf(" %v %v", objToc.DataEntries[uint(oid)].StartByte, objToc.DataEntries[uint(oid)].EndByte))
+			_, _ = w.WriteString(fmt.Sprintf(" %v %v", objToc.DataEntries[uint(oid)].StartByte, objToc.DataEntries[uint(oid)].EndByte))
 		}
-		w.Flush()
+		_ = w.Flush()
 		cmdStr = fmt.Sprintf("%s restore_data_subset %s %s %s", pluginConfig.ExecutablePath, pluginConfig.ConfigPath, fileToRead, offsetsFile.Name())
 		isSubset = true
 	} else {

--- a/history/history.go
+++ b/history/history.go
@@ -89,7 +89,7 @@ func InitializeHistoryDatabase(historyDBPath string) (*sql.DB, error) {
 		return nil, err
 	} else if err == nil {
 		// We don't want an fd handle to it, so close it
-		fd.Close()
+		_ = fd.Close()
 	}
 
 	db, err := sql.Open("sqlite3", historyDBPath)
@@ -134,8 +134,8 @@ func InitializeHistoryDatabase(historyDBPath string) (*sql.DB, error) {
 		);`
 	_, err = tx.Exec(createBackupsTable)
 	if err != nil {
-		tx.Rollback()
-		db.Close()
+		_ = tx.Rollback()
+		_ = db.Close()
 		return nil, err
 	}
 
@@ -150,8 +150,8 @@ func InitializeHistoryDatabase(historyDBPath string) (*sql.DB, error) {
 	for _, auxTable := range auxTables {
 		_, err = tx.Exec(fmt.Sprintf(createAuxTableQuery, auxTable))
 		if err != nil {
-			tx.Rollback()
-			db.Close()
+			_ = tx.Rollback()
+			_ = db.Close()
 			return nil, err
 		}
 	}
@@ -167,8 +167,8 @@ func InitializeHistoryDatabase(historyDBPath string) (*sql.DB, error) {
 		);`
 	_, err = tx.Exec(createRestorePlansTable)
 	if err != nil {
-		tx.Rollback()
-		db.Close()
+		_ = tx.Rollback()
+		_ = db.Close()
 		return nil, err
 	}
 
@@ -181,14 +181,14 @@ func InitializeHistoryDatabase(historyDBPath string) (*sql.DB, error) {
 		);`
 	_, err = tx.Exec(createRestorePlanTablesTable)
 	if err != nil {
-		tx.Rollback()
-		db.Close()
+		_ = tx.Rollback()
+		_ = db.Close()
 		return nil, err
 	}
 
 	err = tx.Commit()
 	if err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, err
 	}
 	return db, nil
@@ -281,12 +281,12 @@ func StoreBackupHistory(db *sql.DB, currentBackupConfig *BackupConfig) error {
 	return err
 
 CleanupError:
-	tx.Rollback()
+	_ = tx.Rollback()
 	return err
 }
 
 func GetMainBackupInfo(timestamp string, historyDB *sql.DB) (BackupConfig, error) {
-	// Retreive main backups information. SQLite doesn't have booleans so convert from ints
+	// Retrieve main backups information. SQLite doesn't have booleans so convert from ints
 	// TODO -- consider passing in a tx instead so that aux tables are coherent with main backups
 	// table. Need to confirm this is possible with sqlite. Unclear if we ever pull in and use aux
 	// table info, so it may not be needed.
@@ -349,7 +349,9 @@ func getAuxTable(db *sql.DB, timestamp, tableName string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer auxTableRows.Close()
+	defer func() {
+		_ = auxTableRows.Close()
+	}()
 
 	auxTableSlice := make([]string, 0)
 	for auxTableRows.Next() {
@@ -397,7 +399,9 @@ func GetBackupConfig(timestamp string, historyDB *sql.DB) (*BackupConfig, error)
 	if err != nil {
 		return nil, err
 	}
-	defer restorePlanRows.Close()
+	defer func() {
+		_ = restorePlanRows.Close()
+	}()
 
 	backupConfig.RestorePlan = make([]RestorePlanEntry, 0)
 	for restorePlanRows.Next() {
@@ -418,8 +422,9 @@ func GetBackupConfig(timestamp string, historyDB *sql.DB) (*BackupConfig, error)
 		if err != nil {
 			return nil, err
 		}
-		defer restorePlanTableRows.Close()
-
+		defer func(rows *sql.Rows) {
+			_ = rows.Close()
+		}(restorePlanTableRows)
 		for restorePlanTableRows.Next() {
 			var tableFQN string
 			err = restorePlanTableRows.Scan(&tableFQN)

--- a/integration/predata_acl_queries_test.go
+++ b/integration/predata_acl_queries_test.go
@@ -432,7 +432,6 @@ LANGUAGE SQL`)
 				structmatcher.ExpectStructsToMatch(&dictionaryMetadata, &resultMetadata)
 			})
 			It("returns a slice of default metadata for a text search configuration", func() {
-				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TS_CONFIGURATION)
 				configurationMetadata := testutils.DefaultMetadata(toc.OBJ_TEXT_SEARCH_CONFIGURATION, false, true, true, false)
 
 				testhelper.AssertQueryRuns(connectionPool, `CREATE TEXT SEARCH CONFIGURATION public.testconfiguration (PARSER = pg_catalog."default");`)
@@ -440,7 +439,7 @@ LANGUAGE SQL`)
 				testhelper.AssertQueryRuns(connectionPool, "COMMENT ON TEXT SEARCH CONFIGURATION public.testconfiguration IS 'This is a text search configuration comment.'")
 
 				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testconfiguration", backup.TYPE_TS_CONFIGURATION)
-				resultMetadataMap = backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TS_CONFIGURATION)
+				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TS_CONFIGURATION)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
 				resultMetadata := resultMetadataMap[uniqueID]
@@ -778,7 +777,6 @@ LANGUAGE SQL`)
 				structmatcher.ExpectStructsToMatch(&dictionaryMetadata, &resultMetadata)
 			})
 			It("returns a slice of default metadata for a text search configuration in a specific schema", func() {
-				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TS_CONFIGURATION)
 				configurationMetadata := testutils.DefaultMetadata(toc.OBJ_TEXT_SEARCH_CONFIGURATION, false, true, true, false)
 
 				testhelper.AssertQueryRuns(connectionPool, `CREATE TEXT SEARCH CONFIGURATION public.testconfiguration (PARSER = pg_catalog."default");`)
@@ -790,7 +788,7 @@ LANGUAGE SQL`)
 				testhelper.AssertQueryRuns(connectionPool, "COMMENT ON TEXT SEARCH CONFIGURATION testschema.testconfiguration IS 'This is a text search configuration comment.'")
 
 				_ = backupCmdFlags.Set(options.INCLUDE_SCHEMA, "testschema")
-				resultMetadataMap = backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TS_CONFIGURATION)
+				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TS_CONFIGURATION)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
 				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testconfiguration", backup.TYPE_TS_CONFIGURATION)

--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -905,7 +905,7 @@ LANGUAGE SQL`)
 		BeforeEach(func() {
 			testutils.SkipIfBefore7(connectionPool)
 		})
-		It("returns a slice of transfroms", func() {
+		It("returns a slice of transforms", func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TRANSFORM FOR pg_catalog.int4 LANGUAGE c (FROM SQL WITH FUNCTION numeric_support(internal), TO SQL WITH FUNCTION int4recv(internal));")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TRANSFORM FOR int4 LANGUAGE c")
 

--- a/options/options.go
+++ b/options/options.go
@@ -392,7 +392,6 @@ func (o Options) GetUserTableRelationsWithIncludeFiltering(connectionPool *dbcon
 			if len(childOids) > 0 {
 				childPartitionFilter = fmt.Sprintf(`OR c.oid IN (%s)`, strings.Join(childOids, ", "))
 			}
-			includeOids = childOids
 		}
 	}
 

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -134,6 +134,7 @@ var _ = Describe("options", func() {
 			_, err = file.WriteString("\n")
 			Expect(err).To(Not(HaveOccurred()))
 			_, err = file.WriteString("\n")
+			Expect(err).To(Not(HaveOccurred()))
 			err = file.Close()
 			Expect(err).To(Not(HaveOccurred()))
 
@@ -167,6 +168,7 @@ var _ = Describe("options", func() {
 			_, err = file.WriteString("\n")
 			Expect(err).To(Not(HaveOccurred()))
 			_, err = file.WriteString("\n")
+			Expect(err).To(Not(HaveOccurred()))
 			err = file.Close()
 			Expect(err).To(Not(HaveOccurred()))
 

--- a/plugins/s3plugin/backup.go
+++ b/plugins/s3plugin/backup.go
@@ -32,7 +32,9 @@ func SetupPluginForBackup(c *cli.Context) error {
 	testFilePath := fmt.Sprintf("%s/%s", localBackupDir, testFileName)
 	fileKey := GetS3Path(config.Options.Folder, testFilePath)
 	file, err := os.Create("/tmp/" + testFileName) // dummy empty reader for probe
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 	if err != nil {
 		return err
 	}
@@ -48,7 +50,9 @@ func BackupFile(c *cli.Context) error {
 	fileName := c.Args().Get(1)
 	fileKey := GetS3Path(config.Options.Folder, fileName)
 	file, err := os.Open(fileName)
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 	if err != nil {
 		return err
 	}
@@ -77,7 +81,7 @@ func BackupDirectory(c *cli.Context) error {
 	// Populate a list of files to be backed up
 	fileList := make([]string, 0)
 	_ = filepath.Walk(dirName, func(path string, f os.FileInfo, err error) error {
-		isDir, _ := isDirectoryGetSize(path)
+		isDir := isDirectory(path)
 		if !isDir {
 			fileList = append(fileList, path)
 		}
@@ -125,7 +129,7 @@ func BackupDirectoryParallel(c *cli.Context) error {
 	// Populate a list of files to be backed up
 	fileList := make([]string, 0)
 	_ = filepath.Walk(dirName, func(path string, f os.FileInfo, err error) error {
-		isDir, _ := isDirectoryGetSize(path)
+		isDir := isDirectory(path)
 		if !isDir {
 			fileList = append(fileList, path)
 		}

--- a/plugins/s3plugin/restore.go
+++ b/plugins/s3plugin/restore.go
@@ -36,7 +36,9 @@ func RestoreFile(c *cli.Context) error {
 	bucket := config.Options.Bucket
 	fileKey := GetS3Path(config.Options.Folder, fileName)
 	file, err := os.Create(fileName)
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 	if err != nil {
 		return err
 	}

--- a/plugins/s3plugin/s3plugin.go
+++ b/plugins/s3plugin/s3plugin.go
@@ -282,19 +282,19 @@ func ShouldEnableEncryption(encryption string) bool {
 	return !isOff
 }
 
-func isDirectoryGetSize(path string) (bool, int64) {
+func isDirectory(path string) bool {
 	fd, err := os.Stat(path)
 	if err != nil {
 		gplog.FatalOnError(err)
 	}
 	switch mode := fd.Mode(); {
 	case mode.IsDir():
-		return true, 0
+		return true
 	case mode.IsRegular():
-		return false, fd.Size()
+		return false
 	}
 	gplog.FatalOnError(errors.New(fmt.Sprintf("INVALID file %s", path)))
-	return false, 0
+	return false
 }
 
 func getFileSize(S3 s3iface.S3API, bucket string, fileKey string) (int64, error) {

--- a/restore/parallel.go
+++ b/restore/parallel.go
@@ -28,7 +28,7 @@ func executeStatementsForConn(statements chan toc.StatementWithType, fatalErr *e
 				gplog.Error("Error detected on connection %d. Terminating transactions.", whichConn)
 				txMutex.Lock()
 				if connectionPool.Tx[whichConn] != nil {
-					connectionPool.Rollback(whichConn)
+					_ = connectionPool.Rollback(whichConn)
 				}
 				txMutex.Unlock()
 			}
@@ -65,7 +65,7 @@ func executeStatementsForConn(statements chan toc.StatementWithType, fatalErr *e
 	if executeInParallel {
 		txMutex.Lock()
 		if connectionPool.Tx[whichConn] != nil {
-			connectionPool.Commit(whichConn)
+			_ = connectionPool.Commit(whichConn)
 		}
 		txMutex.Unlock()
 	}

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -250,21 +250,15 @@ func verifyIncrementalState() {
 
 	var schemasToCreate []string
 	var tableFQNsToCreate []string
-	var schemasExcludedByUserInput []string
-	var tablesExcludedByUserInput []string
 	for _, table := range tableFQNsToRestore {
 		schemaName := strings.Split(table, ".")[0]
 		if utils.SchemaIsExcludedByUser(opts.IncludedSchemas, opts.ExcludedSchemas, schemaName) {
-			if !utils.Exists(schemasExcludedByUserInput, schemaName) {
-				schemasExcludedByUserInput = append(schemasExcludedByUserInput, schemaName)
-			}
-			tablesExcludedByUserInput = append(tablesExcludedByUserInput, table)
 			continue
 		}
 
 		if _, exists := existingTablesMap[table]; !exists {
 			if utils.RelationIsExcludedByUser(opts.IncludedRelations, opts.ExcludedRelations, table) {
-				tablesExcludedByUserInput = append(tablesExcludedByUserInput, table)
+				continue
 			} else {
 				_, schemaExists := existingSchemasMap[schemaName]
 				preFilteredToCreate := utils.Exists(schemasToCreate, schemaName)
@@ -352,7 +346,7 @@ func restorePredata(metadataFilename string) {
 		}
 		numErrors = ExecuteRestoreMetadataStatements("predata", statements, "Pre-data objects", progressBar, utils.PB_VERBOSE, false)
 		if !MustGetFlagBool(options.ON_ERROR_CONTINUE) {
-			connectionPool.Commit(0)
+			_ = connectionPool.Commit(0)
 		}
 	}
 
@@ -691,7 +685,7 @@ func writeErrorTables(isMetadata bool) {
 		}
 		_, _ = errorWriter.WriteString(table)
 	}
-	err = errorWriter.Flush()
+	_ = errorWriter.Flush()
 	err = errorFile.Close()
 	if err != nil {
 		gplog.Warn("Could not close error tables file: %v", err)

--- a/restore/validate.go
+++ b/restore/validate.go
@@ -37,7 +37,7 @@ func ValidateExcludeSchemasInBackupSet(schemaList []string) {
 	}
 }
 
-/* This only checks the globalTOC, but will still succesfully validate tables
+/* This only checks the globalTOC, but will still successfully validate tables
  * in incremental backups since incremental backups will always take backups of
  * the metadata (--incremental and --data-only backup flags are not compatible)
  */
@@ -304,7 +304,7 @@ func ValidateSafeToResizeCluster() {
 			timestamp := MustGetFlagString(options.TIMESTAMP)
 			gplog.Fatal(errors.Errorf("Segment count for backup with timestamp %s is unknown, cannot restore using --resize-cluster flag.", timestamp), "")
 		} else if origSize == destSize {
-			cmdFlags.Set(options.RESIZE_CLUSTER, "false")
+			_ = cmdFlags.Set(options.RESIZE_CLUSTER, "false")
 			gplog.Warn("Backup segment count matches restore segment count; the --resize-cluster flag is not needed.  Proceeding with a normal restore.")
 		} else {
 			gplog.Info("Resize restore specified, will restore a backup set from a %d-segment cluster to a %d-segment cluster", origSize, destSize)

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -256,7 +256,9 @@ func FindHistoricalPluginVersion(timestamp string) string {
 		if err != nil {
 			return historicalPluginVersion
 		}
-		defer historyDB.Close()
+		defer func() {
+			_ = historyDB.Close()
+		}()
 
 		foundBackupConfig, err := history.GetBackupConfig(timestamp, historyDB)
 		if err != nil && err.Error() != "timestamp doesn't match any existing backups" {

--- a/utils/agent_remote_test.go
+++ b/utils/agent_remote_test.go
@@ -149,7 +149,7 @@ var _ = Describe("agent remote", func() {
 		})
 	})
 	Describe("CheckAgentErrorsOnSegments", func() {
-		It("constructs the correct ssh call to check for the existance of an error file on each segment", func() {
+		It("constructs the correct ssh call to check for the existence of an error file on each segment", func() {
 			err := utils.CheckAgentErrorsOnSegments(testCluster, fpInfo)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/utils/plugin_test.go
+++ b/utils/plugin_test.go
@@ -157,6 +157,7 @@ options:
     field3: 567
 `
 				err := os.WriteFile(testConfigPath, []byte(testConfigContents), 0777)
+				Expect(err).ToNot(HaveOccurred())
 				subject.Options["password_encryption"] = "on"
 				mdd := testCluster.GetDirForContent(-1)
 				_ = os.MkdirAll(mdd, 0777)
@@ -372,7 +373,7 @@ options:
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("ERROR: Failed to get plugin name. Failed with error: error executing plugin"))
 		})
-		It("did not recieve expected information from plugin", func() {
+		It("did not receive expected information from plugin", func() {
 			executor.LocalOutput = "bad output"
 			pluginName, err := subject.GetPluginName(testCluster)
 


### PR DESCRIPTION
- Pin `golangci-lint` to `v2.12.2` and install it with `go install`.
- Run golangci-lint in the build workflow.
- Enable additional linters and read-only module resolution.
- Fix the resulting production and test lint findings without changing application logic.
- Update the README lint instructions.

Relates: 
* https://github.com/apache/cloudberry-backup/issues/66
* #86 